### PR TITLE
fix: move mail/calendar toggle to bottom of sidebar

### DIFF
--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -65,10 +65,11 @@
 /* ── Nav toggle: Mail / Calendar ── */
 .navToggle {
   display: flex;
-  padding: 10px 10px 8px;
-  border-bottom: 1px solid var(--border);
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
   gap: 4px;
   flex-shrink: 0;
+  margin-top: auto;
 }
 
 .navBtn {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,29 +55,6 @@ export default function Sidebar({ accounts, unreadCount, calendars }: SidebarPro
         </div>
       </div>
 
-      {/* Mail / Calendar toggle */}
-      <div className={styles.navToggle}>
-        {navItems.map(({ id, icon, label, badge }) => (
-          <button
-            key={id}
-            className={`${styles.navBtn} ${activeView === id ? styles.navBtnActive : ''}`}
-            onClick={() => setActiveView(id)}
-          >
-            <span className={styles.navBtnIcon}>{icon}</span>
-            {label}
-            {badge > 0 && (
-              <span
-                className={`${styles.navBadge} ${
-                  activeView === id ? styles.navBadgeActive : styles.navBadgeInactive
-                }`}
-              >
-                {badge}
-              </span>
-            )}
-          </button>
-        ))}
-      </div>
-
       {/* Compose button (mail mode only) */}
       {activeView === 'mail' && (
         <button className={styles.composeBtn} onClick={() => openCompose({ mode: 'new' })}>
@@ -162,6 +139,29 @@ export default function Sidebar({ accounts, unreadCount, calendars }: SidebarPro
             <CalendarList accounts={accounts} calendars={calendars} />
           </>
         )}
+      </div>
+
+      {/* Mail / Calendar toggle */}
+      <div className={styles.navToggle}>
+        {navItems.map(({ id, icon, label, badge }) => (
+          <button
+            key={id}
+            className={`${styles.navBtn} ${activeView === id ? styles.navBtnActive : ''}`}
+            onClick={() => setActiveView(id)}
+          >
+            <span className={styles.navBtnIcon}>{icon}</span>
+            {label}
+            {badge > 0 && (
+              <span
+                className={`${styles.navBadge} ${
+                  activeView === id ? styles.navBadgeActive : styles.navBadgeInactive
+                }`}
+              >
+                {badge}
+              </span>
+            )}
+          </button>
+        ))}
       </div>
     </aside>
   )


### PR DESCRIPTION
Relocate the Mail/Calendar navToggle from its position below the header to the bottom of the sidebar. This gives primary content (accounts, labels, calendars) more visual prominence.

## Changes

- **Sidebar.tsx**: Moved the navToggle JSX block from after the header to after the modeContent div (bottom of aside)
- **Sidebar.module.css**: Updated \.navToggle\ — changed \order-bottom\ to \order-top\, added \margin-top: auto\ to push it to the bottom, flipped vertical padding

## Verification

- All 178 tests pass
- TypeScript, ESLint checks clean

Closes #13