### PR TITLE
fix: stop reminder popup from stealing focus (#21)

### DIFF
--- a/src-tauri/src/reminders.rs
+++ b/src-tauri/src/reminders.rs
@@ -236,11 +236,12 @@ pub fn show_reminder_window(app: &AppHandle) {
     const WIDTH: i32 = 380;
     const HEIGHT: i32 = 360;
 
-    // If the window already exists, just show + focus it
+    // If the window already exists, just make sure it's visible.
+    // Don't call set_focus() — the window is always-on-top so the user
+    // will see it, but we shouldn't steal focus from their current task.
     if let Some(win) = app.webview_windows().get(LABEL) {
         let _ = win.show();
         let _ = win.unminimize();
-        let _ = win.set_focus();
         return;
     }
 
@@ -256,7 +257,7 @@ pub fn show_reminder_window(app: &AppHandle) {
         .always_on_top(true)
         .skip_taskbar(true)
         .visible(true)
-        .focused(true)
+        .focused(false)
         .build()
     {
         Ok(win) => {


### PR DESCRIPTION
Closes #21

## Problem

The reminder popup window steals focus every time it appears or updates, interrupting whatever the user is doing (typing, browsing, etc.).

## Fix

Two changes in `show_reminder_window()`:

1. **Existing window**: Removed `win.set_focus()` call — the window is already `always_on_top`, so it's visible without grabbing focus.
2. **New window**: Changed `.focused(true)` to `.focused(false)` so the window appears without stealing focus on creation.

The popup still appears on screen (always-on-top, bottom-right corner) and the user can interact with it when they choose to.
