### PR TITLE
feat: prevent multiple app instances (#23)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mogly"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2393,6 +2393,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -4605,6 +4606,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ dotenvy = "0.15"
 tauri-plugin-window-state = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-single-instance = "2"
 notify-rust = "4"
 
 [dev-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,14 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // A second instance tried to launch — focus the existing window instead.
+            if let Some(window) = app.webview_windows().values().next() {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         .manage(AccountStore::new())
         .manage(NotifiedEvents::new())
         .manage(ActiveReminders::new())


### PR DESCRIPTION
Fixes #23

## Problem

Users can accidentally launch multiple instances of Mogly, leading to duplicate tray icons, duplicate background syncs, and potential data conflicts.

## Solution

Add `tauri-plugin-single-instance` which creates a named mutex (on Windows) based on the app's bundle identifier. When a second instance tries to launch:

1. The plugin detects the existing instance
2. The callback focuses the existing main window (show + unminimize + set_focus)
3. The second instance exits silently

## Note on dev/release coexistence

The plugin uses the bundle identifier (`app.mogly`) for the lock. Since dev and release share the same identifier, they also share the single-instance guard. In practice this means you can't run dev and prod simultaneously — but this is a rare developer scenario, and the primary goal is preventing end-users from double-launching.

## Changes

- `src-tauri/Cargo.toml` — add `tauri-plugin-single-instance = "2"`
- `src-tauri/src/lib.rs` — register the plugin with a window-focus callback
