### PR TITLE
fix: deduplicate email list by thread to fix multi-selection (#7)

### DIFF
--- a/src/__tests__/EmailList.test.tsx
+++ b/src/__tests__/EmailList.test.tsx
@@ -225,6 +225,111 @@ describe('EmailList', () => {
     expect(screen.getByText('1 of 2 threads · Inbox')).toBeInTheDocument()
   })
 
+  it('should deduplicate messages by thread_id showing one row per thread', () => {
+    const threadedMessages: MessageMeta[] = [
+      {
+        id: 'm1',
+        thread_id: 't1',
+        account_id: 'a1',
+        from: 'Alice',
+        subject: 'Hello',
+        snippet: 'First message',
+        date: Math.floor(Date.now() / 1000) - 600,
+        unread: false,
+        starred: false,
+        labels: ['INBOX'],
+      },
+      {
+        id: 'm2',
+        thread_id: 't1', // same thread
+        account_id: 'a1',
+        from: 'Bob',
+        subject: 'Re: Hello',
+        snippet: 'Reply message',
+        date: Math.floor(Date.now() / 1000) - 300, // newer
+        unread: false,
+        starred: false,
+        labels: ['INBOX'],
+      },
+      {
+        id: 'm3',
+        thread_id: 't2', // different thread
+        account_id: 'a1',
+        from: 'Charlie',
+        subject: 'Other',
+        snippet: 'Other thread',
+        date: Math.floor(Date.now() / 1000) - 100,
+        unread: false,
+        starred: false,
+        labels: ['INBOX'],
+      },
+    ]
+
+    render(
+      <EmailList
+        messages={threadedMessages}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    // Should show 2 threads, not 3 messages
+    expect(screen.getByText('2 threads · Inbox')).toBeInTheDocument()
+    // Latest message in thread t1 (Bob's reply) should be shown
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+    expect(screen.getByText('Charlie')).toBeInTheDocument()
+    // Alice's older message in same thread should NOT appear as separate row
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument()
+  })
+
+  it('should show thread as unread if any message in thread is unread', async () => {
+    const user = userEvent.setup()
+    const threadedMessages: MessageMeta[] = [
+      {
+        id: 'm1',
+        thread_id: 't1',
+        account_id: 'a1',
+        from: 'Alice',
+        subject: 'Hello',
+        snippet: 'First message',
+        date: Math.floor(Date.now() / 1000) - 600,
+        unread: true, // older message is unread
+        starred: false,
+        labels: ['INBOX', 'UNREAD'],
+      },
+      {
+        id: 'm2',
+        thread_id: 't1', // same thread
+        account_id: 'a1',
+        from: 'Bob',
+        subject: 'Re: Hello',
+        snippet: 'Reply',
+        date: Math.floor(Date.now() / 1000) - 300, // newer, but read
+        unread: false,
+        starred: false,
+        labels: ['INBOX'],
+      },
+    ]
+
+    const { container } = render(
+      <EmailList
+        messages={threadedMessages}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    // Thread should show unread dot (aggregated from older unread message)
+    const unreadDots = container.querySelectorAll('[class*="unreadDot"]')
+    expect(unreadDots.length).toBe(1)
+
+    // Thread should appear when Unread filter is active
+    await user.click(screen.getByText('Unread'))
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+
   it('should show "No matching messages" when filter matches nothing', async () => {
     const user = userEvent.setup()
     const readMessages: MessageMeta[] = [

--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -54,6 +54,40 @@ export default function EmailList({
 
   const accountMap = useMemo(() => new Map(accounts.map((a) => [a.id, a])), [accounts])
 
+  // Deduplicate messages by thread_id — show one row per thread.
+  // Keep the latest message (by date) and aggregate unread/starred
+  // across all messages in the thread. This matches Gmail's inbox
+  // behavior and prevents multiple rows from highlighting on click.
+  const threadMessages = useMemo(() => {
+    if (!messages) return undefined
+    const threadMap = new Map<string, MessageMeta>()
+    for (const msg of messages) {
+      const existing = threadMap.get(msg.thread_id)
+      if (!existing) {
+        // Clone so we can mutate flags without affecting query cache
+        threadMap.set(msg.thread_id, { ...msg })
+      } else {
+        // Keep the latest message as the display row
+        if (msg.date > existing.date) {
+          const wasUnread = existing.unread
+          const wasStarred = existing.starred
+          threadMap.set(msg.thread_id, {
+            ...msg,
+            unread: msg.unread || wasUnread,
+            starred: msg.starred || wasStarred,
+          })
+        } else {
+          // Older message — just aggregate flags
+          existing.unread = existing.unread || msg.unread
+          existing.starred = existing.starred || msg.starred
+        }
+      }
+    }
+    const result = [...threadMap.values()]
+    result.sort((a, b) => b.date - a.date)
+    return result.length > 0 ? result : undefined
+  }, [messages])
+
   const labelName = useMemo(() => {
     const labels: Record<string, string> = {
       INBOX: 'Inbox',
@@ -69,13 +103,13 @@ export default function EmailList({
   const isFiltered = mailFilter.unread || mailFilter.starred
 
   const filteredMessages = useMemo(() => {
-    if (!messages || !isFiltered) return messages
-    return messages.filter((m) => {
+    if (!threadMessages || !isFiltered) return threadMessages
+    return threadMessages.filter((m) => {
       if (mailFilter.unread && !m.unread) return false
       if (mailFilter.starred && !m.starred) return false
       return true
     })
-  }, [messages, mailFilter, isFiltered])
+  }, [threadMessages, mailFilter, isFiltered])
 
   if (isLoading) {
     return (
@@ -88,7 +122,7 @@ export default function EmailList({
     )
   }
 
-  const totalCount = messages?.length ?? 0
+  const totalCount = threadMessages?.length ?? 0
   const displayMessages = filteredMessages ?? []
   const displayCount = displayMessages.length
 
@@ -131,7 +165,7 @@ export default function EmailList({
 
           return (
             <div
-              key={email.id}
+              key={email.thread_id}
               className={`${styles.row} ${isSelected ? styles.rowSelected : ''}`}
               style={{
                 borderLeft: `2.5px solid ${isSelected ? borderColor : borderColor + '44'}`,


### PR DESCRIPTION
Fixes #7

## Problem

The email list showed one row per message, but selection and mark-read operated on entire threads (`thread_id`). This caused:

1. **Multiple rows appeared selected** — clicking one message highlighted all messages in the same thread
2. **Unread filter missed threads** — if only an older message in a thread was unread (but the newest was read), the thread disappeared from the unread filter

## Solution

Deduplicate messages by `thread_id` in `EmailList.tsx`:

- Group messages by `thread_id`, keeping the **latest** message (by date) as the display row
- A thread shows as `unread` if **any** message in it is unread
- A thread shows as `starred` if **any** message in it is starred
- React key changed from `email.id` to `email.thread_id`

This matches Gmail's inbox behavior of showing threads, not individual messages.

## Changes

- `src/components/EmailList.tsx` — thread dedup logic via `useMemo`
- `src/__tests__/EmailList.test.tsx` — 2 new tests for dedup and unread aggregation

## Testing

- 185 tests pass (2 new)
- TypeScript: clean
- ESLint: clean
