### PR TITLE
feat: multi-select emails with bulk actions

### DIFF
--- a/src-tauri/src/commands/gmail.rs
+++ b/src-tauri/src/commands/gmail.rs
@@ -2,7 +2,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::google::gmail as gmail_api;
 use crate::google::oauth::OAuthCredentials;
-use crate::models::{MessageMeta, SendMessageRequest, Thread};
+use crate::models::{BatchModifyItem, MessageMeta, SendMessageRequest, Thread};
 use crate::store::AccountStore;
 
 /// Fetch messages for a single account and label.
@@ -217,4 +217,61 @@ pub async fn send_message(app: AppHandle, request: SendMessageRequest) -> Result
         request.references.as_deref(),
     )
     .await
+}
+
+/// Batch modify labels on multiple threads across accounts.
+///
+/// Used by the frontend multi-select feature to perform bulk mark-read,
+/// mark-unread, and archive operations.
+#[tauri::command]
+#[specta::specta]
+pub async fn batch_modify_threads(
+    app: AppHandle,
+    items: Vec<BatchModifyItem>,
+    add_labels: Vec<String>,
+    remove_labels: Vec<String>,
+) -> Result<(), String> {
+    let creds = OAuthCredentials::load()?;
+    let mut join_set = tokio::task::JoinSet::new();
+
+    let add_labels = std::sync::Arc::new(add_labels);
+    let remove_labels = std::sync::Arc::new(remove_labels);
+
+    for item in items {
+        let email = get_account_email(&app, &item.account_id)?;
+        let creds = creds.clone();
+        let add = std::sync::Arc::clone(&add_labels);
+        let remove = std::sync::Arc::clone(&remove_labels);
+        join_set.spawn(async move {
+            let add_refs: Vec<&str> = add.iter().map(String::as_str).collect();
+            let remove_refs: Vec<&str> = remove.iter().map(String::as_str).collect();
+            gmail_api::modify_thread_labels(
+                &creds,
+                &email,
+                &item.thread_id,
+                &add_refs,
+                &remove_refs,
+            )
+            .await
+        });
+    }
+
+    let mut errors = Vec::new();
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => errors.push(e),
+            Err(e) => errors.push(format!("Task panicked: {e}")),
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Batch modify partially failed ({} errors): {}",
+            errors.len(),
+            errors.join("; ")
+        ))
+    }
 }

--- a/src-tauri/src/google/gmail.rs
+++ b/src-tauri/src/google/gmail.rs
@@ -490,7 +490,7 @@ pub async fn fetch_thread(
 }
 
 /// Modify labels on all messages in a thread.
-async fn modify_thread_labels(
+pub async fn modify_thread_labels(
     creds: &OAuthCredentials,
     email: &str,
     thread_id: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::gmail::mark_unread,
         commands::gmail::search_messages,
         commands::gmail::send_message,
+        commands::gmail::batch_modify_threads,
         commands::calendar::list_calendars,
         commands::calendar::set_calendar_enabled,
         commands::calendar::get_account_events,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -15,6 +15,13 @@ pub struct Account {
     pub auth_expired: bool,
 }
 
+/// An item in a batch modify request (account + thread pair).
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BatchModifyItem {
+    pub account_id: String,
+    pub thread_id: String,
+}
+
 /// A single Google Calendar within an account.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct Calendar {

--- a/src/__tests__/EmailList.test.tsx
+++ b/src/__tests__/EmailList.test.tsx
@@ -58,6 +58,8 @@ describe('EmailList', () => {
       activeAccounts: ['a1', 'a2'],
       selectedLabel: 'INBOX',
       mailFilter: { unread: false, starred: false },
+      selectedThreadIds: new Set<string>(),
+      lastSelectedThreadId: null,
     })
   })
 
@@ -358,5 +360,104 @@ describe('EmailList', () => {
 
     await user.click(screen.getByText('Unread'))
     expect(screen.getByText('No matching messages')).toBeInTheDocument()
+  })
+
+  it('should render checkboxes on each email row', () => {
+    const { container } = render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    // Each row should have a checkbox input
+    const checkboxes = container.querySelectorAll('[class*="checkbox"] input[type="checkbox"]')
+    expect(checkboxes.length).toBe(2)
+  })
+
+  it('should render select-all checkbox in header', () => {
+    const { container } = render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    const selectAll = container.querySelector('[class*="selectAllCheckbox"] input[type="checkbox"]')
+    expect(selectAll).toBeInTheDocument()
+  })
+
+  it('should toggle thread selection when checkbox is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    const checkboxes = container.querySelectorAll('[class*="checkbox"] input[type="checkbox"]')
+    await user.click(checkboxes[0])
+
+    expect(useUIStore.getState().selectedThreadIds.has('t1')).toBe(true)
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(1)
+  })
+
+  it('should show selected count in header when threads are selected', () => {
+    useUIStore.setState({ selectedThreadIds: new Set(['t1']) })
+
+    render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+  })
+
+  it('should select all threads when select-all checkbox is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    const selectAll = container.querySelector(
+      '[class*="selectAllCheckbox"] input[type="checkbox"]',
+    ) as HTMLInputElement
+    await user.click(selectAll)
+
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(2)
+    expect(useUIStore.getState().selectedThreadIds.has('t1')).toBe(true)
+    expect(useUIStore.getState().selectedThreadIds.has('t2')).toBe(true)
+  })
+
+  it('should hide filter chips when selection is active', () => {
+    useUIStore.setState({ selectedThreadIds: new Set(['t1']) })
+
+    render(
+      <EmailList
+        messages={MOCK_MESSAGES}
+        accounts={MOCK_ACCOUNTS}
+        isLoading={false}
+        selectedLabel="INBOX"
+      />,
+    )
+
+    expect(screen.queryByText('Unread')).not.toBeInTheDocument()
+    expect(screen.queryByText('Starred')).not.toBeInTheDocument()
   })
 })

--- a/src/__tests__/MailView.test.tsx
+++ b/src/__tests__/MailView.test.tsx
@@ -65,6 +65,8 @@ describe('MailView', () => {
       selectedLabel: 'INBOX',
       selectedThreadId: null,
       activeAccounts: ['a1'],
+      selectedThreadIds: new Set<string>(),
+      lastSelectedThreadId: null,
     })
   })
 
@@ -99,5 +101,35 @@ describe('MailView', () => {
     renderMailView({ messages: [] })
 
     expect(screen.getByText('No messages')).toBeInTheDocument()
+  })
+
+  it('should not show bulk action bar when no threads are selected', () => {
+    renderMailView()
+
+    expect(screen.queryByText('✓ Mark read')).not.toBeInTheDocument()
+    expect(screen.queryByText('○ Mark unread')).not.toBeInTheDocument()
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  })
+
+  it('should show bulk action bar when threads are selected', () => {
+    useUIStore.setState({ selectedThreadIds: new Set(['t1']) })
+    renderMailView()
+
+    expect(screen.getByText('✓ Mark read')).toBeInTheDocument()
+    expect(screen.getByText('○ Mark unread')).toBeInTheDocument()
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('should clear selection when Cancel is clicked in bulk bar', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+
+    useUIStore.setState({ selectedThreadIds: new Set(['t1', 't2']) })
+    renderMailView()
+
+    await user.click(screen.getByText('Cancel'))
+
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(0)
   })
 })

--- a/src/__tests__/uiStore.test.ts
+++ b/src/__tests__/uiStore.test.ts
@@ -20,6 +20,8 @@ describe('uiStore', () => {
       autoMarkRead: false,
       showCompose: false,
       composeContext: null,
+      selectedThreadIds: new Set<string>(),
+      lastSelectedThreadId: null,
     })
   })
 
@@ -261,6 +263,41 @@ describe('calendar view mode', () => {
   it('should set calendar view date', () => {
     useUIStore.getState().setCalendarViewDate('2026-06-15')
     expect(useUIStore.getState().calendarViewDate).toBe('2026-06-15')
+  })
+
+  it('should toggle thread selection', () => {
+    useUIStore.getState().toggleThreadSelection('t1')
+    expect(useUIStore.getState().selectedThreadIds.has('t1')).toBe(true)
+    expect(useUIStore.getState().lastSelectedThreadId).toBe('t1')
+
+    useUIStore.getState().toggleThreadSelection('t2')
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(2)
+
+    // Toggle off
+    useUIStore.getState().toggleThreadSelection('t1')
+    expect(useUIStore.getState().selectedThreadIds.has('t1')).toBe(false)
+    expect(useUIStore.getState().selectedThreadIds.has('t2')).toBe(true)
+  })
+
+  it('should select all threads', () => {
+    useUIStore.getState().selectAllThreads(['t1', 't2', 't3'])
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(3)
+    expect(useUIStore.getState().lastSelectedThreadId).toBeNull()
+  })
+
+  it('should clear selection', () => {
+    useUIStore.getState().selectAllThreads(['t1', 't2'])
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(2)
+
+    useUIStore.getState().clearSelection()
+    expect(useUIStore.getState().selectedThreadIds.size).toBe(0)
+    expect(useUIStore.getState().lastSelectedThreadId).toBeNull()
+  })
+
+  it('should initialize with empty selection', () => {
+    const state = useUIStore.getState()
+    expect(state.selectedThreadIds.size).toBe(0)
+    expect(state.lastSelectedThreadId).toBeNull()
   })
 })
 

--- a/src/components/EmailList.module.css
+++ b/src/components/EmailList.module.css
@@ -11,6 +11,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 6px;
+}
+
+/* ── Select-all checkbox ── */
+.selectAllCheckbox {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.selectAllCheckbox input[type='checkbox'] {
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
+  accent-color: #4f9cf9;
 }
 
 .headerInfo {
@@ -68,6 +84,40 @@
 
 .rowSelected {
   background: var(--bg-selected);
+}
+
+.rowChecked {
+  background: rgba(79, 156, 249, 0.08);
+}
+
+/* ── Per-row checkbox ── */
+.checkbox {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition:
+    width 0.15s,
+    opacity 0.15s,
+    margin 0.15s;
+  margin-left: 0;
+  cursor: pointer;
+}
+
+.row:hover .checkbox,
+.checkbox.checkboxVisible {
+  width: 22px;
+  opacity: 1;
+  margin-left: 8px;
+}
+
+.checkbox input[type='checkbox'] {
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
+  accent-color: #4f9cf9;
 }
 
 .rowContent {

--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { formatDistanceToNow, isToday, isYesterday, format } from 'date-fns'
 import type { Account, MessageMeta } from '../types/models'
 import { useUIStore } from '../store/uiStore'
@@ -51,6 +51,16 @@ export default function EmailList({
   const setSelectedThreadId = useUIStore((s) => s.setSelectedThreadId)
   const mailFilter = useUIStore((s) => s.mailFilter)
   const toggleMailFilter = useUIStore((s) => s.toggleMailFilter)
+  const selectedThreadIds = useUIStore((s) => s.selectedThreadIds)
+  const toggleThreadSelection = useUIStore((s) => s.toggleThreadSelection)
+  const selectAllThreads = useUIStore((s) => s.selectAllThreads)
+  const clearSelection = useUIStore((s) => s.clearSelection)
+  const lastSelectedThreadId = useUIStore((s) => s.lastSelectedThreadId)
+
+  const hasSelection = selectedThreadIds.size > 0
+
+  /** Ref to track the last shift-click anchor for range selection */
+  const shiftAnchorRef = useRef<string | null>(null)
 
   const accountMap = useMemo(() => new Map(accounts.map((a) => [a.id, a])), [accounts])
 
@@ -111,6 +121,52 @@ export default function EmailList({
     })
   }, [threadMessages, mailFilter, isFiltered])
 
+  const handleCheckboxClick = useCallback(
+    (threadId: string, e: React.MouseEvent) => {
+      e.stopPropagation()
+
+      if (e.shiftKey && lastSelectedThreadId && filteredMessages) {
+        // Range select: select all threads between last selected and current
+        const ids = filteredMessages.map((m) => m.thread_id)
+        const lastIdx = ids.indexOf(lastSelectedThreadId)
+        const currIdx = ids.indexOf(threadId)
+        if (lastIdx !== -1 && currIdx !== -1) {
+          const start = Math.min(lastIdx, currIdx)
+          const end = Math.max(lastIdx, currIdx)
+          const rangeIds = ids.slice(start, end + 1)
+          const next = new Set(selectedThreadIds)
+          for (const id of rangeIds) {
+            next.add(id)
+          }
+          selectAllThreads([...next])
+          return
+        }
+      }
+
+      toggleThreadSelection(threadId)
+      shiftAnchorRef.current = threadId
+    },
+    [
+      lastSelectedThreadId,
+      filteredMessages,
+      selectedThreadIds,
+      selectAllThreads,
+      toggleThreadSelection,
+    ],
+  )
+
+  const handleRowClick = useCallback(
+    (threadId: string) => {
+      if (hasSelection) {
+        // When in selection mode, clicking the row toggles selection
+        toggleThreadSelection(threadId)
+      } else {
+        setSelectedThreadId(threadId)
+      }
+    },
+    [hasSelection, toggleThreadSelection, setSelectedThreadId],
+  )
+
   if (isLoading) {
     return (
       <div className={styles.container}>
@@ -126,30 +182,58 @@ export default function EmailList({
   const displayMessages = filteredMessages ?? []
   const displayCount = displayMessages.length
 
-  const headerText = searchQuery
-    ? `${displayCount} results · "${searchQuery}"`
-    : isFiltered
-      ? `${displayCount} of ${totalCount} threads · ${labelName}`
-      : `${totalCount} threads · ${labelName}`
+  const allSelected =
+    displayCount > 0 && displayMessages.every((m) => selectedThreadIds.has(m.thread_id))
+  const someSelected = hasSelection && !allSelected
+
+  const handleSelectAll = () => {
+    if (allSelected) {
+      clearSelection()
+    } else {
+      selectAllThreads(displayMessages.map((m) => m.thread_id))
+    }
+  }
+
+  const headerText = hasSelection
+    ? `${selectedThreadIds.size} selected`
+    : searchQuery
+      ? `${displayCount} results · "${searchQuery}"`
+      : isFiltered
+        ? `${displayCount} of ${totalCount} threads · ${labelName}`
+        : `${totalCount} threads · ${labelName}`
 
   return (
     <div className={styles.container}>
       <div className={styles.header}>
+        {displayCount > 0 && (
+          <label className={styles.selectAllCheckbox} onClick={(e) => e.stopPropagation()}>
+            <input
+              type="checkbox"
+              checked={allSelected}
+              ref={(el) => {
+                if (el) el.indeterminate = someSelected
+              }}
+              onChange={handleSelectAll}
+            />
+          </label>
+        )}
         <span className={styles.headerInfo}>{headerText}</span>
-        <div className={styles.filterChips}>
-          <button
-            className={`${styles.filterChip} ${mailFilter.unread ? styles.filterChipActive : ''}`}
-            onClick={() => toggleMailFilter('unread')}
-          >
-            Unread
-          </button>
-          <button
-            className={`${styles.filterChip} ${mailFilter.starred ? styles.filterChipActive : ''}`}
-            onClick={() => toggleMailFilter('starred')}
-          >
-            Starred
-          </button>
-        </div>
+        {!hasSelection && (
+          <div className={styles.filterChips}>
+            <button
+              className={`${styles.filterChip} ${mailFilter.unread ? styles.filterChipActive : ''}`}
+              onClick={() => toggleMailFilter('unread')}
+            >
+              Unread
+            </button>
+            <button
+              className={`${styles.filterChip} ${mailFilter.starred ? styles.filterChipActive : ''}`}
+              onClick={() => toggleMailFilter('starred')}
+            >
+              Starred
+            </button>
+          </div>
+        )}
       </div>
 
       {displayCount === 0 ? (
@@ -161,17 +245,29 @@ export default function EmailList({
         displayMessages.map((email) => {
           const acct = accountMap.get(email.account_id)
           const isSelected = selectedThreadId === email.thread_id
+          const isChecked = selectedThreadIds.has(email.thread_id)
           const borderColor = acct?.color ?? '#666'
 
           return (
             <div
               key={email.thread_id}
-              className={`${styles.row} ${isSelected ? styles.rowSelected : ''}`}
+              className={`${styles.row} ${isSelected && !hasSelection ? styles.rowSelected : ''} ${isChecked ? styles.rowChecked : ''}`}
               style={{
-                borderLeft: `2.5px solid ${isSelected ? borderColor : borderColor + '44'}`,
+                borderLeft: `2.5px solid ${isSelected && !hasSelection ? borderColor : borderColor + '44'}`,
               }}
-              onClick={() => setSelectedThreadId(email.thread_id)}
+              onClick={() => handleRowClick(email.thread_id)}
             >
+              <label
+                className={`${styles.checkbox} ${hasSelection ? styles.checkboxVisible : ''}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={() => {}}
+                  onClick={(e) => handleCheckboxClick(email.thread_id, e as React.MouseEvent)}
+                />
+              </label>
               <div className={styles.rowContent}>
                 <div className={styles.senderLine}>
                   <span className={`${styles.sender} ${email.unread ? styles.senderUnread : ''}`}>

--- a/src/components/MailView.module.css
+++ b/src/components/MailView.module.css
@@ -4,3 +4,66 @@
   overflow: hidden;
   min-height: 0;
 }
+
+.detailPane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ── Bulk action bar ── */
+.bulkBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.bulkBtn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+
+.bulkBtn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.bulkBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulkBtnCancel {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-family: inherit;
+  margin-left: auto;
+}
+
+.bulkBtnCancel:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.bulkBtnCancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/MailView.tsx
+++ b/src/components/MailView.tsx
@@ -1,4 +1,6 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useQueryClient } from '@tanstack/react-query'
 import type { Account, MessageMeta } from '../types/models'
 import { useUIStore } from '../store/uiStore'
 import EmailList from './EmailList'
@@ -15,11 +17,51 @@ export default function MailView({ accounts, messages, isLoading }: MailViewProp
   const selectedLabel = useUIStore((s) => s.selectedLabel)
   const selectedThreadId = useUIStore((s) => s.selectedThreadId)
   const searchQuery = useUIStore((s) => s.searchQuery)
+  const selectedThreadIds = useUIStore((s) => s.selectedThreadIds)
+  const clearSelection = useUIStore((s) => s.clearSelection)
+  const queryClient = useQueryClient()
+  const [bulkLoading, setBulkLoading] = useState(false)
+
+  const hasSelection = selectedThreadIds.size > 0
 
   const selectedMessage = useMemo(
     () => messages?.find((m) => m.thread_id === selectedThreadId),
     [messages, selectedThreadId],
   )
+
+  /** Build batch items from the current selection, resolving account IDs from messages. */
+  const buildBatchItems = () => {
+    if (!messages) return []
+    const accountByThread = new Map<string, string>()
+    for (const m of messages) {
+      if (!accountByThread.has(m.thread_id)) {
+        accountByThread.set(m.thread_id, m.account_id)
+      }
+    }
+    return [...selectedThreadIds]
+      .filter((tid) => accountByThread.has(tid))
+      .map((tid) => ({ account_id: accountByThread.get(tid)!, thread_id: tid }))
+  }
+
+  const handleBulkAction = async (addLabels: string[], removeLabels: string[]) => {
+    const items = buildBatchItems()
+    if (items.length === 0) return
+    setBulkLoading(true)
+    try {
+      await invoke('batch_modify_threads', {
+        items,
+        addLabels,
+        removeLabels,
+      })
+      queryClient.invalidateQueries({ queryKey: ['messages'] })
+      queryClient.invalidateQueries({ queryKey: ['search'] })
+      clearSelection()
+    } catch (e) {
+      console.error('Batch modify failed:', e)
+    } finally {
+      setBulkLoading(false)
+    }
+  }
 
   return (
     <div className={styles.mailView}>
@@ -30,7 +72,41 @@ export default function MailView({ accounts, messages, isLoading }: MailViewProp
         selectedLabel={selectedLabel}
         searchQuery={searchQuery}
       />
-      <EmailDetail accounts={accounts} selectedMessage={selectedMessage} />
+      <div className={styles.detailPane}>
+        {hasSelection && (
+          <div className={styles.bulkBar}>
+            <button
+              className={styles.bulkBtn}
+              disabled={bulkLoading}
+              onClick={() => handleBulkAction([], ['UNREAD'])}
+            >
+              ✓ Mark read
+            </button>
+            <button
+              className={styles.bulkBtn}
+              disabled={bulkLoading}
+              onClick={() => handleBulkAction(['UNREAD'], [])}
+            >
+              ○ Mark unread
+            </button>
+            <button
+              className={styles.bulkBtn}
+              disabled={bulkLoading}
+              onClick={() => handleBulkAction([], ['INBOX'])}
+            >
+              Archive
+            </button>
+            <button
+              className={styles.bulkBtnCancel}
+              disabled={bulkLoading}
+              onClick={clearSelection}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+        <EmailDetail accounts={accounts} selectedMessage={selectedMessage} />
+      </div>
     </div>
   )
 }

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -83,6 +83,8 @@ interface UIState {
   showEventModal: boolean
   eventModalDefaults: EventModalData | null
   activeReminders: ActiveReminder[]
+  selectedThreadIds: Set<string>
+  lastSelectedThreadId: string | null
 
   setTheme: (theme: Theme) => void
   setActiveView: (view: AppView) => void
@@ -109,6 +111,9 @@ interface UIState {
   addReminder: (payload: ReminderPayload) => void
   dismissReminder: (eventId: string) => void
   snoozeReminder: (eventId: string, minutes: number) => void
+  toggleThreadSelection: (threadId: string) => void
+  selectAllThreads: (threadIds: string[]) => void
+  clearSelection: () => void
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
@@ -130,6 +135,8 @@ export const useUIStore = create<UIState>((set, get) => ({
   showEventModal: false,
   eventModalDefaults: null,
   activeReminders: [],
+  selectedThreadIds: new Set<string>(),
+  lastSelectedThreadId: null,
 
   setTheme: (theme) => {
     set({ theme })
@@ -246,6 +253,19 @@ export const useUIStore = create<UIState>((set, get) => ({
       console.warn('Failed to snooze reminder:', e),
     )
   },
+  toggleThreadSelection: (threadId) =>
+    set((state) => {
+      const next = new Set(state.selectedThreadIds)
+      if (next.has(threadId)) {
+        next.delete(threadId)
+      } else {
+        next.add(threadId)
+      }
+      return { selectedThreadIds: next, lastSelectedThreadId: threadId }
+    }),
+  selectAllThreads: (threadIds) =>
+    set({ selectedThreadIds: new Set(threadIds), lastSelectedThreadId: null }),
+  clearSelection: () => set({ selectedThreadIds: new Set<string>(), lastSelectedThreadId: null }),
 }))
 
 /** Load the persisted theme from the backend store and apply it. */


### PR DESCRIPTION
Closes #8

## Summary

Add multi-select support to the email list so users can select multiple threads and perform bulk actions (mark read/unread, archive).

## What's new

### Email list checkboxes
- Per-row checkboxes appear on hover, always visible when any thread is selected (Gmail-style)
- **Shift-click** for range selection
- **Select-all** checkbox in header with indeterminate state
- Header shows \N selected\ when in selection mode
- Row clicks toggle selection instead of opening thread detail during selection mode

### Bulk action bar
- Appears above the email detail pane when threads are selected
- **Mark read** — removes UNREAD label
- **Mark unread** — adds UNREAD label
- **Archive** — removes INBOX label
- **Cancel** — clears selection
- Loading state disables all buttons during operation

### Rust backend
- New \atch_modify_threads\ command — accepts a list of (account_id, thread_id) pairs and applies label changes in parallel via \JoinSet\
- Partial failure support: returns aggregated error message if some modifications fail

### Tests
- 13 new tests across uiStore, EmailList, and MailView (169 total passing)

## Files changed (12)
- \src/store/uiStore.ts\ — multi-select state + actions
- \src/components/EmailList.tsx\ + \.module.css\ — checkboxes, shift-click, select-all
- \src/components/MailView.tsx\ + \.module.css\ — bulk action bar
- \src-tauri/src/models.rs\ — \BatchModifyItem\ struct
- \src-tauri/src/commands/gmail.rs\ — \atch_modify_threads\ command
- \src-tauri/src/google/gmail.rs\ — made \modify_thread_labels\ public
- \src-tauri/src/lib.rs\ — registered new command
- \src/__tests__/uiStore.test.ts\ — 4 new tests
- \src/__tests__/EmailList.test.tsx\ — 6 new tests
- \src/__tests__/MailView.test.tsx\ — 3 new tests