### PR TITLE
fix: apply mail filters server-side via Gmail labelIds (#33)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mogly"
-version = "0.2.11"
+version = "0.2.13"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mogly"
-version = "0.2.13"
+version = "0.2.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/commands/gmail.rs
+++ b/src-tauri/src/commands/gmail.rs
@@ -9,6 +9,10 @@ use crate::store::AccountStore;
 ///
 /// The frontend calls this once per account so results stream in as each
 /// account completes independently.
+///
+/// When `filter_unread` or `filter_starred` is true the corresponding Gmail
+/// label is added to the `labelIds` query parameter so the API returns only
+/// matching messages — not just the most recent 50.
 #[tauri::command]
 #[specta::specta]
 pub async fn get_account_messages(
@@ -16,6 +20,8 @@ pub async fn get_account_messages(
     account_id: String,
     label: String,
     page_token: Option<String>,
+    filter_unread: Option<bool>,
+    filter_starred: Option<bool>,
 ) -> Result<Vec<MessageMeta>, String> {
     let creds = OAuthCredentials::load()?;
 
@@ -32,8 +38,16 @@ pub async fn get_account_messages(
             .ok_or_else(|| format!("Account {account_id} not found"))?
     };
 
+    let mut labels = vec![label];
+    if filter_unread.unwrap_or(false) {
+        labels.push("UNREAD".to_string());
+    }
+    if filter_starred.unwrap_or(false) {
+        labels.push("STARRED".to_string());
+    }
+
     let mut messages =
-        gmail_api::fetch_messages(&creds, &account_id, &email, &label, page_token.as_deref())
+        gmail_api::fetch_messages(&creds, &account_id, &email, &labels, page_token.as_deref())
             .await?;
 
     messages.sort_by(|a, b| b.date.cmp(&a.date));
@@ -57,8 +71,9 @@ pub async fn get_messages(
         let app = app.clone();
         let label = label.clone();
         let page_token = page_token.clone();
-        join_set
-            .spawn(async move { get_account_messages(app, account_id, label, page_token).await });
+        join_set.spawn(async move {
+            get_account_messages(app, account_id, label, page_token, None, None).await
+        });
     }
 
     let mut all_messages = Vec::new();

--- a/src-tauri/src/google/gmail.rs
+++ b/src-tauri/src/google/gmail.rs
@@ -27,6 +27,26 @@ struct MessageRef {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct ListThreadsResponse {
+    threads: Option<Vec<ThreadRef>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ThreadRef {
+    id: String,
+}
+
+/// Response from threads.get with format=metadata.
+/// Contains all messages in the thread with their headers and labels.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MetadataThread {
+    messages: Option<Vec<GmailMessage>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct GmailMessage {
     id: String,
     thread_id: String,
@@ -231,7 +251,50 @@ fn parse_full_message(msg: &GmailMessage) -> Message {
 
 // --- Public API functions ---
 
-/// Fetch message metadata for a single account.
+/// Build a `MessageMeta` for a thread from its metadata response.
+///
+/// Uses the latest message for display fields (from, subject, date, snippet)
+/// and OR-aggregates `unread` and `starred` across all messages in the thread
+/// so that a thread with *any* unread message is correctly marked as unread.
+fn parse_thread_meta(thread: &MetadataThread, account_id: &str) -> Option<MessageMeta> {
+    let messages = thread.messages.as_ref()?;
+    if messages.is_empty() {
+        return None;
+    }
+
+    // Find the latest message by internal_date
+    let latest = messages
+        .iter()
+        .max_by_key(|m| {
+            m.internal_date
+                .as_deref()
+                .and_then(|d| d.parse::<i64>().ok())
+                .unwrap_or(0)
+        })
+        .unwrap(); // safe: we checked non-empty above
+
+    let mut meta = parse_message_meta(latest, account_id);
+
+    // OR-aggregate unread/starred across all messages in the thread
+    for msg in messages {
+        let labels = msg.label_ids.as_deref().unwrap_or_default();
+        if labels.iter().any(|l| l == "UNREAD") {
+            meta.unread = true;
+        }
+        if labels.iter().any(|l| l == "STARRED") {
+            meta.starred = true;
+        }
+    }
+
+    Some(meta)
+}
+
+/// Fetch thread metadata for a single account.
+///
+/// Uses `threads.list` instead of `messages.list` so that `maxResults=50`
+/// returns 50 **threads** (not 50 individual messages that may belong to
+/// fewer threads). For each thread, fetches all messages' metadata to
+/// correctly aggregate unread/starred flags across the entire thread.
 pub async fn fetch_messages(
     creds: &OAuthCredentials,
     account_id: &str,
@@ -242,8 +305,8 @@ pub async fn fetch_messages(
     let token = get_valid_token(creds, email).await?;
     let client = reqwest::Client::new();
 
-    // List message IDs
-    let mut url = format!("{GMAIL_BASE_URL}/users/me/messages?labelIds={label}&maxResults=50");
+    // List thread IDs
+    let mut url = format!("{GMAIL_BASE_URL}/users/me/threads?labelIds={label}&maxResults=50");
     if let Some(pt) = page_token {
         let _ = write!(url, "&pageToken={pt}");
     }
@@ -253,50 +316,54 @@ pub async fn fetch_messages(
         .bearer_auth(&token)
         .send()
         .await
-        .map_err(|e| format!("Gmail list request failed: {e}"))?;
+        .map_err(|e| format!("Gmail threads.list request failed: {e}"))?;
 
     if !list_resp.status().is_success() {
         let body = list_resp.text().await.unwrap_or_default();
-        return Err(format!("Gmail list failed: {body}"));
+        return Err(format!("Gmail threads.list failed: {body}"));
     }
 
-    let list_data: ListMessagesResponse = list_resp
+    let list_data: ListThreadsResponse = list_resp
         .json()
         .await
-        .map_err(|e| format!("Failed to parse message list: {e}"))?;
+        .map_err(|e| format!("Failed to parse thread list: {e}"))?;
 
-    let msg_refs = list_data.messages.unwrap_or_default();
-    if msg_refs.is_empty() {
+    let thread_refs = list_data.threads.unwrap_or_default();
+    if thread_refs.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Fetch metadata for all messages in parallel
+    // Fetch metadata for each thread in parallel
     let mut join_set = tokio::task::JoinSet::new();
-    for msg_ref in msg_refs {
+    for thread_ref in thread_refs {
         let client = client.clone();
         let token = token.clone();
         let account_id = account_id.to_string();
-        let msg_id = msg_ref.id;
+        let thread_id = thread_ref.id;
         join_set.spawn(async move {
-            let msg_url = format!(
-                "{GMAIL_BASE_URL}/users/me/messages/{msg_id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date",
+            let thread_url = format!(
+                "{GMAIL_BASE_URL}/users/me/threads/{thread_id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date",
             );
-            let msg_resp = client
-                .get(&msg_url)
+            let resp = client
+                .get(&thread_url)
                 .bearer_auth(&token)
                 .send()
                 .await
-                .map_err(|e| format!("Gmail get message failed: {e}"))?;
+                .map_err(|e| format!("Gmail threads.get failed: {e}"))?;
 
-            if !msg_resp.status().is_success() {
-                return Err(format!("Gmail get message {msg_id} failed: {}", msg_resp.status()));
+            if !resp.status().is_success() {
+                return Err(format!(
+                    "Gmail threads.get {thread_id} failed: {}",
+                    resp.status()
+                ));
             }
 
-            let gmail_msg: GmailMessage = msg_resp
+            let metadata_thread: MetadataThread = resp
                 .json()
                 .await
-                .map_err(|e| format!("Failed to parse message: {e}"))?;
-            Ok(parse_message_meta(&gmail_msg, &account_id))
+                .map_err(|e| format!("Failed to parse thread metadata: {e}"))?;
+            parse_thread_meta(&metadata_thread, &account_id)
+                .ok_or_else(|| format!("Thread {thread_id} has no messages"))
         });
     }
 
@@ -304,8 +371,8 @@ pub async fn fetch_messages(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(Ok(meta)) => messages.push(meta),
-            Ok(Err(e)) => log::warn!("Skipping message: {e}"),
-            Err(e) => log::warn!("Message fetch task panicked: {e}"),
+            Ok(Err(e)) => log::warn!("Skipping thread: {e}"),
+            Err(e) => log::warn!("Thread fetch task panicked: {e}"),
         }
     }
 
@@ -1070,5 +1137,108 @@ mod tests {
         // Should decode back to original
         let decoded = URL_SAFE_NO_PAD.decode(&encoded).unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), raw);
+    }
+
+    #[test]
+    fn test_parse_thread_meta_aggregates_unread_starred() {
+        // Thread with 3 messages: M1 (old, unread), M2 (middle, read+starred),
+        // M3 (newest, read). The thread should show as unread AND starred because
+        // we OR-aggregate across all messages.
+        let thread = MetadataThread {
+            messages: Some(vec![
+                GmailMessage {
+                    id: "m1".to_string(),
+                    thread_id: "thread-1".to_string(),
+                    label_ids: Some(vec!["INBOX".to_string(), "UNREAD".to_string()]),
+                    snippet: Some("Old message".to_string()),
+                    internal_date: Some("1700000000000".to_string()),
+                    payload: Some(MessagePart {
+                        mime_type: None,
+                        headers: Some(vec![
+                            Header {
+                                name: "From".to_string(),
+                                value: "alice@example.com".to_string(),
+                            },
+                            Header {
+                                name: "Subject".to_string(),
+                                value: "Thread Subject".to_string(),
+                            },
+                        ]),
+                        body: None,
+                        parts: None,
+                        filename: None,
+                    }),
+                },
+                GmailMessage {
+                    id: "m2".to_string(),
+                    thread_id: "thread-1".to_string(),
+                    label_ids: Some(vec!["INBOX".to_string(), "STARRED".to_string()]),
+                    snippet: Some("Middle message".to_string()),
+                    internal_date: Some("1700000100000".to_string()),
+                    payload: Some(MessagePart {
+                        mime_type: None,
+                        headers: Some(vec![
+                            Header {
+                                name: "From".to_string(),
+                                value: "bob@example.com".to_string(),
+                            },
+                            Header {
+                                name: "Subject".to_string(),
+                                value: "Re: Thread Subject".to_string(),
+                            },
+                        ]),
+                        body: None,
+                        parts: None,
+                        filename: None,
+                    }),
+                },
+                GmailMessage {
+                    id: "m3".to_string(),
+                    thread_id: "thread-1".to_string(),
+                    label_ids: Some(vec!["INBOX".to_string()]),
+                    snippet: Some("Newest message".to_string()),
+                    internal_date: Some("1700000200000".to_string()),
+                    payload: Some(MessagePart {
+                        mime_type: None,
+                        headers: Some(vec![
+                            Header {
+                                name: "From".to_string(),
+                                value: "charlie@example.com".to_string(),
+                            },
+                            Header {
+                                name: "Subject".to_string(),
+                                value: "Re: Thread Subject".to_string(),
+                            },
+                        ]),
+                        body: None,
+                        parts: None,
+                        filename: None,
+                    }),
+                },
+            ]),
+        };
+
+        let meta = parse_thread_meta(&thread, "acc-1").unwrap();
+
+        // Display fields come from the newest message (m3)
+        assert_eq!(meta.id, "m3");
+        assert_eq!(meta.from, "charlie@example.com");
+        assert_eq!(meta.snippet, "Newest message");
+        assert_eq!(meta.date, 1_700_000_200);
+
+        // unread/starred are OR-aggregated across all messages
+        assert!(meta.unread, "thread should be unread (m1 is UNREAD)");
+        assert!(meta.starred, "thread should be starred (m2 is STARRED)");
+    }
+
+    #[test]
+    fn test_parse_thread_meta_empty_returns_none() {
+        let thread = MetadataThread {
+            messages: Some(vec![]),
+        };
+        assert!(parse_thread_meta(&thread, "acc-1").is_none());
+
+        let thread_none = MetadataThread { messages: None };
+        assert!(parse_thread_meta(&thread_none, "acc-1").is_none());
     }
 }

--- a/src-tauri/src/google/gmail.rs
+++ b/src-tauri/src/google/gmail.rs
@@ -27,26 +27,6 @@ struct MessageRef {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ListThreadsResponse {
-    threads: Option<Vec<ThreadRef>>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ThreadRef {
-    id: String,
-}
-
-/// Response from threads.get with format=metadata.
-/// Contains all messages in the thread with their headers and labels.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct MetadataThread {
-    messages: Option<Vec<GmailMessage>>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct GmailMessage {
     id: String,
     thread_id: String,
@@ -251,50 +231,7 @@ fn parse_full_message(msg: &GmailMessage) -> Message {
 
 // --- Public API functions ---
 
-/// Build a `MessageMeta` for a thread from its metadata response.
-///
-/// Uses the latest message for display fields (from, subject, date, snippet)
-/// and OR-aggregates `unread` and `starred` across all messages in the thread
-/// so that a thread with *any* unread message is correctly marked as unread.
-fn parse_thread_meta(thread: &MetadataThread, account_id: &str) -> Option<MessageMeta> {
-    let messages = thread.messages.as_ref()?;
-    if messages.is_empty() {
-        return None;
-    }
-
-    // Find the latest message by internal_date
-    let latest = messages
-        .iter()
-        .max_by_key(|m| {
-            m.internal_date
-                .as_deref()
-                .and_then(|d| d.parse::<i64>().ok())
-                .unwrap_or(0)
-        })
-        .unwrap(); // safe: we checked non-empty above
-
-    let mut meta = parse_message_meta(latest, account_id);
-
-    // OR-aggregate unread/starred across all messages in the thread
-    for msg in messages {
-        let labels = msg.label_ids.as_deref().unwrap_or_default();
-        if labels.iter().any(|l| l == "UNREAD") {
-            meta.unread = true;
-        }
-        if labels.iter().any(|l| l == "STARRED") {
-            meta.starred = true;
-        }
-    }
-
-    Some(meta)
-}
-
-/// Fetch thread metadata for a single account.
-///
-/// Uses `threads.list` instead of `messages.list` so that `maxResults=50`
-/// returns 50 **threads** (not 50 individual messages that may belong to
-/// fewer threads). For each thread, fetches all messages' metadata to
-/// correctly aggregate unread/starred flags across the entire thread.
+/// Fetch message metadata for a single account.
 pub async fn fetch_messages(
     creds: &OAuthCredentials,
     account_id: &str,
@@ -305,8 +242,8 @@ pub async fn fetch_messages(
     let token = get_valid_token(creds, email).await?;
     let client = reqwest::Client::new();
 
-    // List thread IDs
-    let mut url = format!("{GMAIL_BASE_URL}/users/me/threads?labelIds={label}&maxResults=50");
+    // List message IDs
+    let mut url = format!("{GMAIL_BASE_URL}/users/me/messages?labelIds={label}&maxResults=50");
     if let Some(pt) = page_token {
         let _ = write!(url, "&pageToken={pt}");
     }
@@ -316,54 +253,50 @@ pub async fn fetch_messages(
         .bearer_auth(&token)
         .send()
         .await
-        .map_err(|e| format!("Gmail threads.list request failed: {e}"))?;
+        .map_err(|e| format!("Gmail list request failed: {e}"))?;
 
     if !list_resp.status().is_success() {
         let body = list_resp.text().await.unwrap_or_default();
-        return Err(format!("Gmail threads.list failed: {body}"));
+        return Err(format!("Gmail list failed: {body}"));
     }
 
-    let list_data: ListThreadsResponse = list_resp
+    let list_data: ListMessagesResponse = list_resp
         .json()
         .await
-        .map_err(|e| format!("Failed to parse thread list: {e}"))?;
+        .map_err(|e| format!("Failed to parse message list: {e}"))?;
 
-    let thread_refs = list_data.threads.unwrap_or_default();
-    if thread_refs.is_empty() {
+    let msg_refs = list_data.messages.unwrap_or_default();
+    if msg_refs.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Fetch metadata for each thread in parallel
+    // Fetch metadata for all messages in parallel
     let mut join_set = tokio::task::JoinSet::new();
-    for thread_ref in thread_refs {
+    for msg_ref in msg_refs {
         let client = client.clone();
         let token = token.clone();
         let account_id = account_id.to_string();
-        let thread_id = thread_ref.id;
+        let msg_id = msg_ref.id;
         join_set.spawn(async move {
-            let thread_url = format!(
-                "{GMAIL_BASE_URL}/users/me/threads/{thread_id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date",
+            let msg_url = format!(
+                "{GMAIL_BASE_URL}/users/me/messages/{msg_id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date",
             );
-            let resp = client
-                .get(&thread_url)
+            let msg_resp = client
+                .get(&msg_url)
                 .bearer_auth(&token)
                 .send()
                 .await
-                .map_err(|e| format!("Gmail threads.get failed: {e}"))?;
+                .map_err(|e| format!("Gmail get message failed: {e}"))?;
 
-            if !resp.status().is_success() {
-                return Err(format!(
-                    "Gmail threads.get {thread_id} failed: {}",
-                    resp.status()
-                ));
+            if !msg_resp.status().is_success() {
+                return Err(format!("Gmail get message {msg_id} failed: {}", msg_resp.status()));
             }
 
-            let metadata_thread: MetadataThread = resp
+            let gmail_msg: GmailMessage = msg_resp
                 .json()
                 .await
-                .map_err(|e| format!("Failed to parse thread metadata: {e}"))?;
-            parse_thread_meta(&metadata_thread, &account_id)
-                .ok_or_else(|| format!("Thread {thread_id} has no messages"))
+                .map_err(|e| format!("Failed to parse message: {e}"))?;
+            Ok(parse_message_meta(&gmail_msg, &account_id))
         });
     }
 
@@ -371,8 +304,8 @@ pub async fn fetch_messages(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(Ok(meta)) => messages.push(meta),
-            Ok(Err(e)) => log::warn!("Skipping thread: {e}"),
-            Err(e) => log::warn!("Thread fetch task panicked: {e}"),
+            Ok(Err(e)) => log::warn!("Skipping message: {e}"),
+            Err(e) => log::warn!("Message fetch task panicked: {e}"),
         }
     }
 
@@ -1137,108 +1070,5 @@ mod tests {
         // Should decode back to original
         let decoded = URL_SAFE_NO_PAD.decode(&encoded).unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), raw);
-    }
-
-    #[test]
-    fn test_parse_thread_meta_aggregates_unread_starred() {
-        // Thread with 3 messages: M1 (old, unread), M2 (middle, read+starred),
-        // M3 (newest, read). The thread should show as unread AND starred because
-        // we OR-aggregate across all messages.
-        let thread = MetadataThread {
-            messages: Some(vec![
-                GmailMessage {
-                    id: "m1".to_string(),
-                    thread_id: "thread-1".to_string(),
-                    label_ids: Some(vec!["INBOX".to_string(), "UNREAD".to_string()]),
-                    snippet: Some("Old message".to_string()),
-                    internal_date: Some("1700000000000".to_string()),
-                    payload: Some(MessagePart {
-                        mime_type: None,
-                        headers: Some(vec![
-                            Header {
-                                name: "From".to_string(),
-                                value: "alice@example.com".to_string(),
-                            },
-                            Header {
-                                name: "Subject".to_string(),
-                                value: "Thread Subject".to_string(),
-                            },
-                        ]),
-                        body: None,
-                        parts: None,
-                        filename: None,
-                    }),
-                },
-                GmailMessage {
-                    id: "m2".to_string(),
-                    thread_id: "thread-1".to_string(),
-                    label_ids: Some(vec!["INBOX".to_string(), "STARRED".to_string()]),
-                    snippet: Some("Middle message".to_string()),
-                    internal_date: Some("1700000100000".to_string()),
-                    payload: Some(MessagePart {
-                        mime_type: None,
-                        headers: Some(vec![
-                            Header {
-                                name: "From".to_string(),
-                                value: "bob@example.com".to_string(),
-                            },
-                            Header {
-                                name: "Subject".to_string(),
-                                value: "Re: Thread Subject".to_string(),
-                            },
-                        ]),
-                        body: None,
-                        parts: None,
-                        filename: None,
-                    }),
-                },
-                GmailMessage {
-                    id: "m3".to_string(),
-                    thread_id: "thread-1".to_string(),
-                    label_ids: Some(vec!["INBOX".to_string()]),
-                    snippet: Some("Newest message".to_string()),
-                    internal_date: Some("1700000200000".to_string()),
-                    payload: Some(MessagePart {
-                        mime_type: None,
-                        headers: Some(vec![
-                            Header {
-                                name: "From".to_string(),
-                                value: "charlie@example.com".to_string(),
-                            },
-                            Header {
-                                name: "Subject".to_string(),
-                                value: "Re: Thread Subject".to_string(),
-                            },
-                        ]),
-                        body: None,
-                        parts: None,
-                        filename: None,
-                    }),
-                },
-            ]),
-        };
-
-        let meta = parse_thread_meta(&thread, "acc-1").unwrap();
-
-        // Display fields come from the newest message (m3)
-        assert_eq!(meta.id, "m3");
-        assert_eq!(meta.from, "charlie@example.com");
-        assert_eq!(meta.snippet, "Newest message");
-        assert_eq!(meta.date, 1_700_000_200);
-
-        // unread/starred are OR-aggregated across all messages
-        assert!(meta.unread, "thread should be unread (m1 is UNREAD)");
-        assert!(meta.starred, "thread should be starred (m2 is STARRED)");
-    }
-
-    #[test]
-    fn test_parse_thread_meta_empty_returns_none() {
-        let thread = MetadataThread {
-            messages: Some(vec![]),
-        };
-        assert!(parse_thread_meta(&thread, "acc-1").is_none());
-
-        let thread_none = MetadataThread { messages: None };
-        assert!(parse_thread_meta(&thread_none, "acc-1").is_none());
     }
 }

--- a/src-tauri/src/google/gmail.rs
+++ b/src-tauri/src/google/gmail.rs
@@ -232,18 +232,28 @@ fn parse_full_message(msg: &GmailMessage) -> Message {
 // --- Public API functions ---
 
 /// Fetch message metadata for a single account.
+///
+/// `labels` contains one or more Gmail label IDs that are sent as `labelIds`
+/// query parameters. Gmail returns only messages that have **all** of the
+/// specified labels, so passing `["INBOX", "UNREAD"]` returns only unread
+/// inbox messages.
 pub async fn fetch_messages(
     creds: &OAuthCredentials,
     account_id: &str,
     email: &str,
-    label: &str,
+    labels: &[String],
     page_token: Option<&str>,
 ) -> Result<Vec<MessageMeta>, String> {
     let token = get_valid_token(creds, email).await?;
     let client = reqwest::Client::new();
 
-    // List message IDs
-    let mut url = format!("{GMAIL_BASE_URL}/users/me/messages?labelIds={label}&maxResults=50");
+    // List message IDs — each label becomes a separate labelIds param
+    let label_params: String = labels
+        .iter()
+        .map(|l| format!("labelIds={l}"))
+        .collect::<Vec<_>>()
+        .join("&");
+    let mut url = format!("{GMAIL_BASE_URL}/users/me/messages?{label_params}&maxResults=50");
     if let Some(pt) = page_token {
         let _ = write!(url, "&pageToken={pt}");
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ function AppShell() {
   const activeView = useUIStore((s) => s.activeView)
   const activeAccounts = useUIStore((s) => s.activeAccounts)
   const selectedLabel = useUIStore((s) => s.selectedLabel)
+  const mailFilter = useUIStore((s) => s.mailFilter)
   const calendarWeekStart = useUIStore((s) => s.calendarWeekStart)
   const calendarViewMode = useUIStore((s) => s.calendarViewMode)
   const calendarViewDate = useUIStore((s) => s.calendarViewDate)
@@ -64,6 +65,7 @@ function AppShell() {
   const { data: messages, isLoading: messagesLoading } = useMessages(
     healthyAccountIds,
     selectedLabel,
+    mailFilter,
   )
   const { data: searchResults, isLoading: searchLoading } = useSearchMessages(
     healthyAccountIds,

--- a/src/__tests__/EmailList.test.tsx
+++ b/src/__tests__/EmailList.test.tsx
@@ -189,7 +189,7 @@ describe('EmailList', () => {
     expect(screen.getByText('Starred')).toBeInTheDocument()
   })
 
-  it('should filter to unread messages when Unread chip is clicked', async () => {
+  it('should toggle mailFilter.unread in the store when Unread chip is clicked', async () => {
     const user = userEvent.setup()
     render(
       <EmailList
@@ -199,16 +199,17 @@ describe('EmailList', () => {
         selectedLabel="INBOX"
       />,
     )
+
+    // Filter is off initially
+    expect(useUIStore.getState().mailFilter.unread).toBe(false)
 
     await user.click(screen.getByText('Unread'))
 
-    // Alice is unread, Bob is not
-    expect(screen.getByText('Alice')).toBeInTheDocument()
-    expect(screen.queryByText('Bob')).not.toBeInTheDocument()
-    expect(screen.getByText('1 of 2 threads · Inbox')).toBeInTheDocument()
+    // Clicking the chip toggles the store flag (server-side filter via query key)
+    expect(useUIStore.getState().mailFilter.unread).toBe(true)
   })
 
-  it('should filter to starred messages when Starred chip is clicked', async () => {
+  it('should toggle mailFilter.starred in the store when Starred chip is clicked', async () => {
     const user = userEvent.setup()
     render(
       <EmailList
@@ -219,12 +220,13 @@ describe('EmailList', () => {
       />,
     )
 
+    // Filter is off initially
+    expect(useUIStore.getState().mailFilter.starred).toBe(false)
+
     await user.click(screen.getByText('Starred'))
 
-    // Bob is starred, Alice is not
-    expect(screen.getByText('Bob')).toBeInTheDocument()
-    expect(screen.queryByText('Alice')).not.toBeInTheDocument()
-    expect(screen.getByText('1 of 2 threads · Inbox')).toBeInTheDocument()
+    // Clicking the chip toggles the store flag (server-side filter via query key)
+    expect(useUIStore.getState().mailFilter.starred).toBe(true)
   })
 
   it('should deduplicate messages by thread_id showing one row per thread', () => {
@@ -285,8 +287,7 @@ describe('EmailList', () => {
     expect(screen.queryByText('Alice')).not.toBeInTheDocument()
   })
 
-  it('should show thread as unread if any message in thread is unread', async () => {
-    const user = userEvent.setup()
+  it('should show thread as unread if any message in thread is unread', () => {
     const threadedMessages: MessageMeta[] = [
       {
         id: 'm1',
@@ -327,38 +328,18 @@ describe('EmailList', () => {
     const unreadDots = container.querySelectorAll('[class*="unreadDot"]')
     expect(unreadDots.length).toBe(1)
 
-    // Thread should appear when Unread filter is active
-    await user.click(screen.getByText('Unread'))
+    // Thread row should show the newest message (Bob) with unread styling
     expect(screen.getByText('Bob')).toBeInTheDocument()
   })
 
-  it('should show "No matching messages" when filter matches nothing', async () => {
-    const user = userEvent.setup()
-    const readMessages: MessageMeta[] = [
-      {
-        id: 'm1',
-        thread_id: 't1',
-        account_id: 'a1',
-        from: 'Alice',
-        subject: 'Hello',
-        snippet: 'Hey there...',
-        date: Math.floor(Date.now() / 1000) - 300,
-        unread: false,
-        starred: false,
-        labels: ['INBOX'],
-      },
-    ]
+  it('should show "No matching messages" when filter is active and server returns no results', () => {
+    // Pre-set filter in store (simulates user having clicked Unread)
+    useUIStore.setState({ mailFilter: { unread: true, starred: false } })
 
     render(
-      <EmailList
-        messages={readMessages}
-        accounts={MOCK_ACCOUNTS}
-        isLoading={false}
-        selectedLabel="INBOX"
-      />,
+      <EmailList messages={[]} accounts={MOCK_ACCOUNTS} isLoading={false} selectedLabel="INBOX" />,
     )
 
-    await user.click(screen.getByText('Unread'))
     expect(screen.getByText('No matching messages')).toBeInTheDocument()
   })
 

--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -112,22 +112,13 @@ export default function EmailList({
 
   const isFiltered = mailFilter.unread || mailFilter.starred
 
-  const filteredMessages = useMemo(() => {
-    if (!threadMessages || !isFiltered) return threadMessages
-    return threadMessages.filter((m) => {
-      if (mailFilter.unread && !m.unread) return false
-      if (mailFilter.starred && !m.starred) return false
-      return true
-    })
-  }, [threadMessages, mailFilter, isFiltered])
-
   const handleCheckboxClick = useCallback(
     (threadId: string, e: React.MouseEvent) => {
       e.stopPropagation()
 
-      if (e.shiftKey && lastSelectedThreadId && filteredMessages) {
+      if (e.shiftKey && lastSelectedThreadId && threadMessages) {
         // Range select: select all threads between last selected and current
-        const ids = filteredMessages.map((m) => m.thread_id)
+        const ids = threadMessages.map((m) => m.thread_id)
         const lastIdx = ids.indexOf(lastSelectedThreadId)
         const currIdx = ids.indexOf(threadId)
         if (lastIdx !== -1 && currIdx !== -1) {
@@ -148,7 +139,7 @@ export default function EmailList({
     },
     [
       lastSelectedThreadId,
-      filteredMessages,
+      threadMessages,
       selectedThreadIds,
       selectAllThreads,
       toggleThreadSelection,
@@ -178,8 +169,7 @@ export default function EmailList({
     )
   }
 
-  const totalCount = threadMessages?.length ?? 0
-  const displayMessages = filteredMessages ?? []
+  const displayMessages = threadMessages ?? []
   const displayCount = displayMessages.length
 
   const allSelected =
@@ -198,9 +188,7 @@ export default function EmailList({
     ? `${selectedThreadIds.size} selected`
     : searchQuery
       ? `${displayCount} results · "${searchQuery}"`
-      : isFiltered
-        ? `${displayCount} of ${totalCount} threads · ${labelName}`
-        : `${totalCount} threads · ${labelName}`
+      : `${displayCount} threads · ${labelName}`
 
   return (
     <div className={styles.container}>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -3,23 +3,38 @@ import { useQueries } from '@tanstack/react-query'
 import { invoke } from '@tauri-apps/api/core'
 import type { MessageMeta } from '../types/models'
 
+interface MailFilter {
+  unread: boolean
+  starred: boolean
+}
+
 /**
  * Fetch messages for the given accounts and label.
  *
  * Issues one query **per account** in parallel so each account's messages
  * stream in independently — the first to finish renders immediately.
+ *
+ * When `mailFilter.unread` or `mailFilter.starred` is active, the filter is
+ * passed to the Gmail API as additional `labelIds` so the server returns only
+ * matching messages — not just the most recent 50.
  */
-export function useMessages(activeAccountIds: string[], selectedLabel: string) {
+export function useMessages(
+  activeAccountIds: string[],
+  selectedLabel: string,
+  mailFilter: MailFilter,
+) {
   const enabled = activeAccountIds.length > 0
 
   const queries = useQueries({
     queries: activeAccountIds.map((accountId) => ({
-      queryKey: ['messages', accountId, selectedLabel],
+      queryKey: ['messages', accountId, selectedLabel, mailFilter.unread, mailFilter.starred],
       queryFn: () =>
         invoke<MessageMeta[]>('get_account_messages', {
           accountId,
           label: selectedLabel,
           pageToken: null,
+          filterUnread: mailFilter.unread,
+          filterStarred: mailFilter.starred,
         }),
       enabled,
     })),


### PR DESCRIPTION
## Problem

Unread/starred filters only filtered client-side within the 50 most recent messages. Old unread emails beyond that window were invisible when the filter was active.

## Solution

Pass filter flags to the backend, which adds `UNREAD`/`STARRED` to the Gmail API `labelIds` query parameter. The server now returns only matching messages regardless of age.

### Changes
- `useMessages` passes `filterUnread`/`filterStarred` to `get_account_messages`
- `get_account_messages` builds a multi-label vec from base label + filter labels
- `fetch_messages` accepts `&[String]` and emits multiple `labelIds` params
- Removed client-side `filteredMessages` logic from `EmailList`
- Updated tests to reflect server-side filtering

Closes #33