### PR TITLE
fix: avoid destroying tokens on transient Linux keychain failures (#46)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mogly"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -34,16 +34,36 @@ pub fn store_tokens(email: &str, tokens: &StoredTokens) -> Result<(), String> {
     Ok(())
 }
 
+const KEYCHAIN_RETRIES: u32 = 3;
+const KEYCHAIN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Retrieve tokens from the OS keychain.
+///
+/// Retries up to [`KEYCHAIN_RETRIES`] times with a short delay between
+/// attempts to work around transient Secret Service / D-Bus failures on
+/// Linux.
 pub fn get_tokens(email: &str) -> Result<StoredTokens, String> {
     let entry = keyring::Entry::new(SERVICE_NAME, email)
         .map_err(|e| format!("Keychain entry error: {e}"))?;
-    let json = entry
-        .get_password()
-        .map_err(|e| format!("Keychain retrieve error: {e}"))?;
-    let tokens: StoredTokens =
-        serde_json::from_str(&json).map_err(|e| format!("Deserialize error: {e}"))?;
-    Ok(tokens)
+
+    let mut last_err = String::new();
+    for attempt in 0..KEYCHAIN_RETRIES {
+        match entry.get_password() {
+            Ok(json) => {
+                let tokens: StoredTokens =
+                    serde_json::from_str(&json).map_err(|e| format!("Deserialize error: {e}"))?;
+                return Ok(tokens);
+            }
+            Err(e) => {
+                last_err = format!("Keychain retrieve error: {e}");
+                if attempt + 1 < KEYCHAIN_RETRIES {
+                    std::thread::sleep(KEYCHAIN_RETRY_DELAY);
+                }
+            }
+        }
+    }
+
+    Err(last_err)
 }
 
 /// Delete tokens from the OS keychain.

--- a/src-tauri/src/reminders.rs
+++ b/src-tauri/src/reminders.rs
@@ -11,7 +11,7 @@ use crate::google::oauth::OAuthCredentials;
 use crate::keychain;
 use crate::models::ReminderPayload;
 use crate::store::{self, AccountStore};
-use crate::sync::is_auth_error;
+use crate::sync::{is_auth_error, is_auth_revoked, is_keychain_error};
 
 const REMINDER_CHECK_SECS: u64 = 60;
 const REMINDER_WINDOW_SECS: i64 = 600; // 10 minutes
@@ -110,15 +110,21 @@ async fn check_upcoming_events(app: &AppHandle) {
         }
         if let Err(e) =
             check_account_events(app, &creds, account, &enabled_state, now, time_max).await
-            && is_auth_error(&e)
         {
-            warn!(
-                "Calendar reminders: auth failed for {}, marking account: {e}",
-                account.email
-            );
-            let _ = store::set_auth_expired(app, &account.id, true);
-            let _ = keychain::delete_tokens(&account.email);
-            let _ = app.emit("account:auth_expired", &account.id);
+            if is_auth_revoked(&e) {
+                warn!(
+                    "Calendar reminders: auth revoked for {}, marking account: {e}",
+                    account.email
+                );
+                let _ = store::set_auth_expired(app, &account.id, true);
+                let _ = keychain::delete_tokens(&account.email);
+                let _ = app.emit("account:auth_expired", &account.id);
+            } else if is_keychain_error(&e) {
+                warn!(
+                    "Calendar reminders: keychain unavailable for {}, will retry: {e}",
+                    account.email
+                );
+            }
         }
     }
 }

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -27,14 +27,26 @@ impl NotifiedMessages {
     }
 }
 
-/// Check if an error string indicates an authentication/authorization failure
-/// that should mark the account as needing re-authentication.
-pub fn is_auth_error(error: &str) -> bool {
+/// Check if an error indicates Google rejected the token — the user must
+/// re-authenticate.
+pub fn is_auth_revoked(error: &str) -> bool {
     error.starts_with("AUTH_EXPIRED:")
         || error.contains("invalid_grant")
         || error.contains("UNAUTHENTICATED")
         || error.contains("Invalid Credentials")
-        || error.contains("Keychain retrieve error")
+}
+
+/// Check if an error indicates the OS keyring was inaccessible (transient on
+/// Linux with Secret Service / D-Bus backends).
+pub fn is_keychain_error(error: &str) -> bool {
+    error.contains("Keychain retrieve error")
+}
+
+/// Convenience: returns `true` for any auth-related error (revoked **or**
+/// keychain). Used by callers that propagate errors upward and let the
+/// top-level handler distinguish between the two cases.
+pub fn is_auth_error(error: &str) -> bool {
+    is_auth_revoked(error) || is_keychain_error(error)
 }
 
 /// Fast notification pipe — polls `history.list` every 15 seconds.
@@ -110,14 +122,20 @@ async fn check_all_accounts(app: &AppHandle) {
                     found_new = true;
                 }
             }
-            Err(e) if is_auth_error(&e) => {
+            Err(e) if is_auth_revoked(&e) => {
                 warn!(
-                    "Background sync: auth failed for {}, marking account: {e}",
+                    "Background sync: auth revoked for {}, marking account: {e}",
                     account.email
                 );
                 let _ = store::set_auth_expired(app, &account.id, true);
                 let _ = keychain::delete_tokens(&account.email);
                 let _ = app.emit("account:auth_expired", &account.id);
+            }
+            Err(e) if is_keychain_error(&e) => {
+                warn!(
+                    "Background sync: keychain unavailable for {}, will retry: {e}",
+                    account.email
+                );
             }
             Err(e) => {
                 error!("Background sync: failed for {}: {e}", account.email);
@@ -384,5 +402,53 @@ mod tests {
 
         // Only msg-3 should be novel
         assert_eq!(novel, vec!["msg-3"]);
+    }
+
+    #[test]
+    fn test_is_auth_revoked_sentinel() {
+        assert!(is_auth_revoked("AUTH_EXPIRED:user@example.com"));
+    }
+
+    #[test]
+    fn test_is_auth_revoked_invalid_grant() {
+        assert!(is_auth_revoked("Token refresh failed: invalid_grant"));
+    }
+
+    #[test]
+    fn test_is_auth_revoked_unauthenticated() {
+        assert!(is_auth_revoked(
+            r#"Gmail history.list failed: {"error":{"status":"UNAUTHENTICATED"}}"#
+        ));
+    }
+
+    #[test]
+    fn test_is_auth_revoked_invalid_credentials() {
+        assert!(is_auth_revoked(
+            r#"Gmail history.list failed: {"error":{"errors":[{"message":"Invalid Credentials"}]}}"#
+        ));
+    }
+
+    #[test]
+    fn test_is_auth_revoked_not_keychain() {
+        assert!(!is_auth_revoked("Keychain retrieve error: item not found"));
+    }
+
+    #[test]
+    fn test_is_keychain_error() {
+        assert!(is_keychain_error("Keychain retrieve error: item not found"));
+        assert!(is_keychain_error("Keychain retrieve error: dbus timeout"));
+    }
+
+    #[test]
+    fn test_is_keychain_error_not_auth() {
+        assert!(!is_keychain_error("AUTH_EXPIRED:user@example.com"));
+        assert!(!is_keychain_error("Token refresh failed: invalid_grant"));
+    }
+
+    #[test]
+    fn test_is_auth_error_includes_both() {
+        assert!(is_auth_error("AUTH_EXPIRED:user@example.com"));
+        assert!(is_auth_error("Keychain retrieve error: locked"));
+        assert!(!is_auth_error("Network timeout"));
     }
 }


### PR DESCRIPTION
Distinguish between Google-revoked tokens (invalid_grant, UNAUTHENTICATED) and transient OS keyring failures (Secret Service locked after suspend, D-Bus timeout). Only delete tokens and mark auth_expired for confirmed revocations; keychain errors log a warning and retry next cycle.

Add retry logic (3 attempts, 500ms delay) to keychain::get_tokens to ride out transient Secret Service failures on Linux.