### PR TITLE
fix: display multi-day events across all spanned day columns

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mogly"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src/__tests__/CalendarView.test.tsx
+++ b/src/__tests__/CalendarView.test.tsx
@@ -356,4 +356,54 @@ describe('CalendarView', () => {
     expect(block).toBeDefined()
     expect(block.textContent).toContain('Draggable Event')
   })
+
+  it('renders multi-day all-day events in all spanned day columns', () => {
+    // 3-day event: Wed Mar 4 through Fri Mar 6 (end is exclusive per Google Calendar)
+    const events = [
+      makeEvent({
+        id: 'multi1',
+        title: 'Conference',
+        start: new Date('2026-03-04T00:00:00').getTime() / 1000,
+        end: new Date('2026-03-07T00:00:00').getTime() / 1000,
+        all_day: true,
+      }),
+    ]
+
+    const { container } = render(
+      <Wrapper>
+        <CalendarView events={events} accounts={MOCK_ACCOUNTS} isLoading={false} />
+      </Wrapper>,
+    )
+
+    // The event should appear in 3 day columns (Wed, Thu, Fri)
+    const allDayEls = container.querySelectorAll('[class*="allDayEvent"]')
+    const conferenceEls = Array.from(allDayEls).filter((el) =>
+      el.textContent?.includes('Conference'),
+    )
+    expect(conferenceEls.length).toBe(3)
+  })
+
+  it('renders multi-day event that starts before the visible week', () => {
+    // Event starts on Sunday Mar 1 (before the Monday start) and ends Wed Mar 4
+    const events = [
+      makeEvent({
+        id: 'pre-week',
+        title: 'Sprint',
+        start: new Date('2026-03-01T00:00:00').getTime() / 1000,
+        end: new Date('2026-03-05T00:00:00').getTime() / 1000,
+        all_day: true,
+      }),
+    ]
+
+    const { container } = render(
+      <Wrapper>
+        <CalendarView events={events} accounts={MOCK_ACCOUNTS} isLoading={false} />
+      </Wrapper>,
+    )
+
+    // Should appear on Mon, Tue, Wed (3 days within the visible week)
+    const allDayEls = container.querySelectorAll('[class*="allDayEvent"]')
+    const sprintEls = Array.from(allDayEls).filter((el) => el.textContent?.includes('Sprint'))
+    expect(sprintEls.length).toBe(3)
+  })
 })

--- a/src/__tests__/EventModal.test.tsx
+++ b/src/__tests__/EventModal.test.tsx
@@ -98,8 +98,8 @@ describe('EventModal', () => {
       <EventModal accounts={MOCK_ACCOUNTS} calendars={MOCK_CALENDARS} onSaved={vi.fn()} />,
     )
 
-    const dateInput = screen.getByDisplayValue('2026-03-15')
-    expect(dateInput).toBeInTheDocument()
+    const dateInputs = screen.getAllByDisplayValue('2026-03-15')
+    expect(dateInputs).toHaveLength(2) // start date + end date
 
     const startInput = screen.getByDisplayValue('10:00')
     expect(startInput).toBeInTheDocument()

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -304,6 +304,16 @@ export default function CalendarView({
       const startTimeStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`
       const endTimeStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`
 
+      const isAllDay = ev.all_day || ev.end - ev.start >= 86400
+      // For multi-day all-day events, compute inclusive end date (day before
+      // Google's exclusive end timestamp).
+      let endDateStr: string | undefined
+      if (isAllDay) {
+        const lastDay = new Date(ev.end * 1000)
+        lastDay.setDate(lastDay.getDate() - 1)
+        endDateStr = `${lastDay.getFullYear()}-${pad2(lastDay.getMonth() + 1)}-${pad2(lastDay.getDate())}`
+      }
+
       openEventModal({
         mode: 'edit',
         date: dateStr,
@@ -313,7 +323,8 @@ export default function CalendarView({
         accountId: ev.account_id,
         calendarId: ev.calendar_id,
         title: ev.title,
-        allDay: ev.all_day || ev.end - ev.start >= 86400,
+        allDay: isAllDay,
+        endDate: endDateStr,
         location: ev.location ?? undefined,
         description: ev.description ?? undefined,
         conferenceUrl: ev.conference_url ?? undefined,
@@ -742,6 +753,10 @@ export default function CalendarView({
                     const color = eventColor(ev, accounts)
                     const cal = calendars.find((c) => c.id === ev.calendar_id)
                     const acct = accounts.find((a) => a.id === ev.account_id)
+                    const totalDays = Math.ceil((ev.end - ev.start) / 86400)
+                    const dayStartTs =
+                      new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime() / 1000
+                    const dayOfEvent = Math.floor((dayStartTs - ev.start) / 86400) + 1
                     return (
                       <div
                         key={ev.id}
@@ -754,6 +769,7 @@ export default function CalendarView({
                         onClick={() => openEditModal(ev)}
                       >
                         {ev.title}
+                        {totalDays > 1 && ` · Day ${dayOfEvent}/${totalDays}`}
 
                         {/* Hover popover */}
                         <div className={styles.eventPopover}>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -305,13 +305,16 @@ export default function CalendarView({
       const endTimeStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`
 
       const isAllDay = ev.all_day || ev.end - ev.start >= 86400
-      // For multi-day all-day events, compute inclusive end date (day before
-      // Google's exclusive end timestamp).
-      let endDateStr: string | undefined
+      // Compute the end date string. For all-day events Google uses an
+      // exclusive end, so subtract one day to get the inclusive end date.
+      // For timed events use the end timestamp date directly.
+      let endDateStr: string
       if (isAllDay) {
         const lastDay = new Date(ev.end * 1000)
         lastDay.setDate(lastDay.getDate() - 1)
         endDateStr = `${lastDay.getFullYear()}-${pad2(lastDay.getMonth() + 1)}-${pad2(lastDay.getDate())}`
+      } else {
+        endDateStr = `${endDate.getFullYear()}-${pad2(endDate.getMonth() + 1)}-${pad2(endDate.getDate())}`
       }
 
       openEventModal({

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -516,15 +516,16 @@ export default function CalendarView({
       // return full-day events as timed events spanning midnight-to-midnight)
       const isAllDay = event.all_day || event.end - event.start >= 86400
 
-      // Find which day column(s) this event belongs to
-      const startDate = new Date(event.start * 1000)
+      // Find all day columns this event overlaps with (supports multi-day events)
       for (let i = 0; i < dayCount; i++) {
         const day = weekDays[i]
-        if (
-          startDate.getFullYear() === day.getFullYear() &&
-          startDate.getMonth() === day.getMonth() &&
-          startDate.getDate() === day.getDate()
-        ) {
+        const dayStartTs =
+          new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime() / 1000
+        const dayEndTs = dayStartTs + 86400
+
+        // Event overlaps this day if it starts before the day ends
+        // and ends after the day starts
+        if (event.start < dayEndTs && event.end > dayStartTs) {
           if (isAllDay) {
             map.get(i)!.allDay.push(event)
           } else {

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -153,6 +153,7 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
 
   const [titleValue, setTitle] = useState(initial.title ?? '')
   const [date, setDate] = useState(initial.date)
+  const [endDate, setEndDate] = useState(initial.endDate ?? initial.date)
   const [startTime, setStartTime] = useState(initial.startTime)
   const [endTime, setEndTime] = useState(initial.endTime)
   const [allDay, setAllDay] = useState(initial.allDay ?? false)
@@ -277,24 +278,30 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
     void timezone // used later in the invoke call
 
     if (allDay) {
-      const startDate = new Date(`${date}T00:00:00`)
-      const endDate = new Date(startDate)
-      endDate.setDate(endDate.getDate() + 1)
+      if (endDate < date) {
+        setError('End date must be on or after start date')
+        return null
+      }
+      const startD = new Date(`${date}T00:00:00`)
+      // Google Calendar uses exclusive end dates for all-day events,
+      // so add one day to the inclusive end date.
+      const endD = new Date(`${endDate}T00:00:00`)
+      endD.setDate(endD.getDate() + 1)
       return {
-        startTs: Math.floor(startDate.getTime() / 1000),
-        endTs: Math.floor(endDate.getTime() / 1000),
+        startTs: Math.floor(startD.getTime() / 1000),
+        endTs: Math.floor(endD.getTime() / 1000),
       }
     }
 
-    const startDate = new Date(`${date}T${startTime}:00`)
-    const endDate = new Date(`${date}T${endTime}:00`)
-    if (endDate <= startDate) {
+    const startD = new Date(`${date}T${startTime}:00`)
+    const endD = new Date(`${date}T${endTime}:00`)
+    if (endD <= startD) {
       setError('End time must be after start time')
       return null
     }
     return {
-      startTs: Math.floor(startDate.getTime() / 1000),
-      endTs: Math.floor(endDate.getTime() / 1000),
+      startTs: Math.floor(startD.getTime() / 1000),
+      endTs: Math.floor(endD.getTime() / 1000),
     }
   }
 
@@ -440,27 +447,63 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
             />
           </div>
 
-          {/* Date */}
-          <div className={styles.field}>
-            <span className={styles.label}>Date</span>
-            <input
-              type="date"
-              className={styles.input}
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-            />
-          </div>
-
           {/* All-day toggle */}
           <div className={styles.checkboxRow}>
             <input
               type="checkbox"
               id="allDay"
               checked={allDay}
-              onChange={(e) => setAllDay(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked
+                setAllDay(checked)
+                if (checked && endDate < date) {
+                  setEndDate(date)
+                }
+              }}
             />
             <label htmlFor="allDay">All day</label>
           </div>
+
+          {/* Date fields — two fields when all-day, single field otherwise */}
+          {allDay ? (
+            <div className={styles.row}>
+              <div className={styles.field}>
+                <span className={styles.label}>Start date</span>
+                <input
+                  type="date"
+                  className={styles.input}
+                  value={date}
+                  onChange={(e) => {
+                    const newDate = e.target.value
+                    setDate(newDate)
+                    if (endDate < newDate) {
+                      setEndDate(newDate)
+                    }
+                  }}
+                />
+              </div>
+              <div className={styles.field}>
+                <span className={styles.label}>End date</span>
+                <input
+                  type="date"
+                  className={styles.input}
+                  value={endDate}
+                  min={date}
+                  onChange={(e) => setEndDate(e.target.value)}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className={styles.field}>
+              <span className={styles.label}>Date</span>
+              <input
+                type="date"
+                className={styles.input}
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+              />
+            </div>
+          )}
 
           {/* Time pickers — hidden when all-day */}
           {!allDay && (

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -294,9 +294,9 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
     }
 
     const startD = new Date(`${date}T${startTime}:00`)
-    const endD = new Date(`${date}T${endTime}:00`)
+    const endD = new Date(`${endDate}T${endTime}:00`)
     if (endD <= startD) {
-      setError('End time must be after start time')
+      setError('End must be after start')
       return null
     }
     return {
@@ -464,46 +464,34 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
             <label htmlFor="allDay">All day</label>
           </div>
 
-          {/* Date fields — two fields when all-day, single field otherwise */}
-          {allDay ? (
-            <div className={styles.row}>
-              <div className={styles.field}>
-                <span className={styles.label}>Start date</span>
-                <input
-                  type="date"
-                  className={styles.input}
-                  value={date}
-                  onChange={(e) => {
-                    const newDate = e.target.value
-                    setDate(newDate)
-                    if (endDate < newDate) {
-                      setEndDate(newDate)
-                    }
-                  }}
-                />
-              </div>
-              <div className={styles.field}>
-                <span className={styles.label}>End date</span>
-                <input
-                  type="date"
-                  className={styles.input}
-                  value={endDate}
-                  min={date}
-                  onChange={(e) => setEndDate(e.target.value)}
-                />
-              </div>
-            </div>
-          ) : (
+          {/* Date fields — always show start + end date */}
+          <div className={styles.row}>
             <div className={styles.field}>
-              <span className={styles.label}>Date</span>
+              <span className={styles.label}>Start date</span>
               <input
                 type="date"
                 className={styles.input}
                 value={date}
-                onChange={(e) => setDate(e.target.value)}
+                onChange={(e) => {
+                  const newDate = e.target.value
+                  setDate(newDate)
+                  if (endDate < newDate) {
+                    setEndDate(newDate)
+                  }
+                }}
               />
             </div>
-          )}
+            <div className={styles.field}>
+              <span className={styles.label}>End date</span>
+              <input
+                type="date"
+                className={styles.input}
+                value={endDate}
+                min={date}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
+            </div>
+          </div>
 
           {/* Time pickers — hidden when all-day */}
           {!allDay && (

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -80,16 +80,21 @@ export default function MonthView({
 
   const isCurrentMonth = (d: Date) => d.getFullYear() === viewYear && d.getMonth() === viewMonth - 1
 
-  // Group events by date key "YYYY-MM-DD"
+  // Group events by date key "YYYY-MM-DD", spanning all days for multi-day events
   const eventsByDate = useMemo(() => {
     const map = new Map<string, CalEvent[]>()
     if (!events) return map
     for (const ev of events) {
-      const d = new Date(ev.start * 1000)
-      const key = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
-      const list = map.get(key) ?? []
-      list.push(ev)
-      map.set(key, list)
+      const startD = new Date(ev.start * 1000)
+      // Iterate each day the event spans
+      const cursor = new Date(startD.getFullYear(), startD.getMonth(), startD.getDate())
+      while (cursor.getTime() / 1000 < ev.end) {
+        const key = `${cursor.getFullYear()}-${pad2(cursor.getMonth() + 1)}-${pad2(cursor.getDate())}`
+        const list = map.get(key) ?? []
+        list.push(ev)
+        map.set(key, list)
+        cursor.setDate(cursor.getDate() + 1)
+      }
     }
     return map
   }, [events])

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -109,13 +109,16 @@ export default function MonthView({
       const endTimeStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`
 
       const isAllDay = ev.all_day || ev.end - ev.start >= 86400
-      // For multi-day all-day events, compute inclusive end date (day before
-      // Google's exclusive end timestamp).
-      let endDateStr: string | undefined
+      // Compute the end date string. For all-day events Google uses an
+      // exclusive end, so subtract one day to get the inclusive end date.
+      // For timed events use the end timestamp date directly.
+      let endDateStr: string
       if (isAllDay) {
         const lastDay = new Date(ev.end * 1000)
         lastDay.setDate(lastDay.getDate() - 1)
         endDateStr = `${lastDay.getFullYear()}-${pad2(lastDay.getMonth() + 1)}-${pad2(lastDay.getDate())}`
+      } else {
+        endDateStr = `${endDate.getFullYear()}-${pad2(endDate.getMonth() + 1)}-${pad2(endDate.getDate())}`
       }
 
       openEventModal({

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -108,6 +108,16 @@ export default function MonthView({
       const startTimeStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`
       const endTimeStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`
 
+      const isAllDay = ev.all_day || ev.end - ev.start >= 86400
+      // For multi-day all-day events, compute inclusive end date (day before
+      // Google's exclusive end timestamp).
+      let endDateStr: string | undefined
+      if (isAllDay) {
+        const lastDay = new Date(ev.end * 1000)
+        lastDay.setDate(lastDay.getDate() - 1)
+        endDateStr = `${lastDay.getFullYear()}-${pad2(lastDay.getMonth() + 1)}-${pad2(lastDay.getDate())}`
+      }
+
       openEventModal({
         mode: 'edit',
         date: dateStr,
@@ -117,7 +127,8 @@ export default function MonthView({
         accountId: ev.account_id,
         calendarId: ev.calendar_id,
         title: ev.title,
-        allDay: ev.all_day || ev.end - ev.start >= 86400,
+        allDay: isAllDay,
+        endDate: endDateStr,
         location: ev.location ?? undefined,
         description: ev.description ?? undefined,
         conferenceUrl: ev.conference_url ?? undefined,

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -20,6 +20,8 @@ export interface EventModalData {
   calendarId?: string
   title?: string
   allDay?: boolean
+  /** End date for multi-day all-day events (YYYY-MM-DD, inclusive). */
+  endDate?: string
   location?: string
   description?: string
   conferenceUrl?: string


### PR DESCRIPTION
Closes #45

## Problem
Multi-day events (e.g. a week-long conference) only appeared on their start day in both the week and month calendar views.

## Root cause
`eventsByDay` in `CalendarView.tsx` and `eventsByDate` in `MonthView.tsx` assigned events to day columns by comparing only the event's start date to each column.

## Fix
Replace the start-date-only match with an overlap check: an event appears in every day column where `event.start < dayEnd && event.end > dayStart`. This correctly handles events that span multiple days, including events that start before or end after the visible range.

## Testing
Added two new test cases:
- A 3-day all-day event appears in all 3 spanned day columns
- An event starting before the visible week still renders on the overlapping days