### PR TITLE
fix: app does not exit when main window is closed

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,7 +87,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .menu(&menu)
         .on_menu_event(|app, event| match event.id().as_ref() {
             "open" => {
-                if let Some(window) = app.webview_windows().values().next() {
+                if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.unminimize();
                     let _ = window.set_focus();
@@ -105,7 +105,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             } = event
             {
                 let app = tray.app_handle();
-                if let Some(window) = app.webview_windows().values().next() {
+                if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.unminimize();
                     let _ = window.set_focus();
@@ -147,6 +147,7 @@ pub fn run() {
                         "window-state.json"
                     }
                 })
+                .with_denylist(&["reminder-popup"])
                 .build(),
         )
         .plugin(tauri_plugin_notification::init())
@@ -160,7 +161,7 @@ pub fn run() {
             #[cfg(not(debug_assertions))]
             {
                 tauri_plugin_single_instance::init(|app, _args, _cwd| {
-                    if let Some(window) = app.webview_windows().values().next() {
+                    if let Some(window) = app.get_webview_window("main") {
                         let _ = window.show();
                         let _ = window.unminimize();
                         let _ = window.set_focus();
@@ -198,11 +199,18 @@ pub fn run() {
 
             // In debug builds, prefix the window title so dev is visually distinct
             #[cfg(debug_assertions)]
-            if let Some(window) = app.webview_windows().values().next() {
+            if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_title("[DEV] Mogly");
             }
 
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::Destroyed = event
+                && window.label() == "main"
+            {
+                window.app_handle().exit(0);
+            }
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/ReminderPopupWindow.tsx
+++ b/src/components/ReminderPopupWindow.tsx
@@ -54,7 +54,7 @@ export default function ReminderPopupWindow() {
       hadRemindersRef.current = true
     } else if (hadRemindersRef.current) {
       getCurrentWindow()
-        .hide()
+        .close()
         .catch(() => {
           // Window may already be closed
         })


### PR DESCRIPTION
## Problem

When the user clicks the X button on the main window, the app does not exit. Clicking the taskbar icon afterwards opens the reminder popup window instead of the main window. The user must manually kill the process to recover.

## Root Causes

Three interrelated issues:

1. **Reminder popup stays alive after dismissal.** `ReminderPopupWindow.tsx` called `getCurrentWindow().hide()` when all reminders were dismissed, keeping the window in Tauri's registry. Tauri v2 only exits when ALL windows are destroyed, so the hidden window prevented exit.

2. **Non-deterministic window lookup.** All 4 window lookup sites in `lib.rs` used `app.webview_windows().values().next()`, which returns an arbitrary window from a HashMap. After the main window was destroyed, the only remaining window was the hidden reminder popup, so tray/taskbar clicks showed the wrong window.

3. **No close event handling.** There was no `on_window_event` handler, so nothing detected or reacted to the main window being closed.

## Fix

- Replace `webview_windows().values().next()` with `get_webview_window("main")` in all 4 call sites (tray menu, tray click, single-instance, setup)
- Change reminder popup from `hide()` to `close()` so it is fully destroyed when empty (`show_reminder_window()` already handles recreation)
- Add `on_window_event` handler to exit the app when the main window is destroyed
- Exclude `reminder-popup` from the window-state plugin via `with_denylist`

Closes #41