### PR TITLE
feat: add keyboard shortcuts to modals (Escape / Ctrl+Enter)

### DIFF
--- a/src/__tests__/ComposeModal.test.tsx
+++ b/src/__tests__/ComposeModal.test.tsx
@@ -187,4 +187,57 @@ describe('ComposeModal', () => {
 
     expect(screen.getByText('personal@test.com')).toBeInTheDocument()
   })
+
+  it('should close compose when Escape key is pressed', async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({ composeContext: { mode: 'new' } })
+
+    renderWithQuery(<ComposeModal accounts={MOCK_ACCOUNTS} />)
+
+    await user.keyboard('{Escape}')
+
+    expect(useUIStore.getState().showCompose).toBe(false)
+    expect(useUIStore.getState().composeContext).toBeNull()
+  })
+
+  it('should send message when Ctrl+Enter is pressed', async () => {
+    const user = userEvent.setup()
+    mockedInvoke.mockResolvedValueOnce(undefined)
+
+    useUIStore.setState({
+      composeContext: {
+        mode: 'reply',
+        threadId: 't1',
+        accountId: 'a1',
+        to: 'alice@example.com',
+        subject: 'Hello',
+        body: '',
+      },
+    })
+
+    renderWithQuery(<ComposeModal accounts={MOCK_ACCOUNTS} />)
+
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    await waitFor(() => {
+      expect(mockedInvoke).toHaveBeenCalledWith('send_message', {
+        request: expect.objectContaining({
+          account_id: 'a1',
+          to: ['alice@example.com'],
+          subject: 'Re: Hello',
+        }),
+      })
+    })
+  })
+
+  it('should not send when Ctrl+Enter is pressed with empty To field', async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({ composeContext: { mode: 'new' } })
+
+    renderWithQuery(<ComposeModal accounts={MOCK_ACCOUNTS} />)
+
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    expect(mockedInvoke).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/EventModal.test.tsx
+++ b/src/__tests__/EventModal.test.tsx
@@ -314,4 +314,31 @@ describe('EventModal', () => {
 
     expect(startInput.value).toBe('10:00')
   })
+
+  it('should close modal when Escape key is pressed', async () => {
+    const user = userEvent.setup()
+
+    renderWithQuery(
+      <EventModal accounts={MOCK_ACCOUNTS} calendars={MOCK_CALENDARS} onSaved={vi.fn()} />,
+    )
+
+    await user.keyboard('{Escape}')
+
+    const state = useUIStore.getState()
+    expect(state.showEventModal).toBe(false)
+    expect(state.eventModalDefaults).toBeNull()
+  })
+
+  it('should attempt save when Ctrl+Enter is pressed', async () => {
+    const user = userEvent.setup()
+
+    renderWithQuery(
+      <EventModal accounts={MOCK_ACCOUNTS} calendars={MOCK_CALENDARS} onSaved={vi.fn()} />,
+    )
+
+    // With empty title, Ctrl+Enter should trigger validation error
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    expect(screen.getByText('Title is required')).toBeInTheDocument()
+  })
 })

--- a/src/components/ComposeModal.tsx
+++ b/src/components/ComposeModal.tsx
@@ -112,6 +112,23 @@ export default function ComposeModal({ accounts }: ComposeModalProps) {
     if (e.target === e.currentTarget) closeCompose()
   }
 
+  // Keyboard shortcuts: Escape → close, Ctrl/Cmd+Enter → send
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeCompose()
+      }
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        if (!sending && to.trim()) {
+          void handleSend()
+        }
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  })
+
   return (
     <div className={styles.backdrop} onClick={handleBackdropClick} data-testid="compose-backdrop">
       <div className={styles.modal}>

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -422,6 +422,23 @@ export default function EventModal({ accounts, calendars, onSaved }: EventModalP
     if (e.target === e.currentTarget) closeEventModal()
   }
 
+  // Keyboard shortcuts: Escape → close, Ctrl/Cmd+Enter → save
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeEventModal()
+      }
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        if (!sending) {
+          void handleSave()
+        }
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  })
+
   return (
     <div className={styles.backdrop} onClick={handleBackdropClick}>
       <div className={styles.modal}>


### PR DESCRIPTION
## Summary

Adds keyboard support to ComposeModal and EventModal per issue #43.

**Escape** closes either modal (same as clicking Discard, the close button, or the backdrop).

**Ctrl/Cmd+Enter** triggers the primary action:
- ComposeModal: sends the message (gated on non-empty To field and not already sending)
- EventModal: saves the event (gated on not already sending; title validation still applies)

Bare Enter is intentionally not intercepted so that textareas (email body, event description) continue to accept newlines normally.

## Changes

- `ComposeModal.tsx` — added `useEffect` keyboard listener
- `EventModal.tsx` — added `useEffect` keyboard listener
- `ComposeModal.test.tsx` — 3 new tests (Escape, Ctrl+Enter send, Ctrl+Enter with empty To)
- `EventModal.test.tsx` — 2 new tests (Escape, Ctrl+Enter save with validation)

Closes #43