### PR TITLE
fix: show re-auth prompt at runtime when OAuth token expires

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import TopBar from './components/TopBar'
 import MailView from './components/MailView'
 import CalendarView from './components/CalendarView'
 import MonthView from './components/MonthView'
+import AuthExpiredBanner from './components/AuthExpiredBanner'
 import NotificationBanner from './components/NotificationBanner'
 import UpdateBanner from './components/UpdateBanner'
 import ComposeModal from './components/ComposeModal'
@@ -123,6 +124,21 @@ function AppShell() {
     }
   }, [])
 
+  // Listen for backend auth-expired events and refresh all queries so the
+  // Sidebar shows the re-authenticate button without requiring a restart.
+  useEffect(() => {
+    const unlisten = listen('account:auth_expired', () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['messages'] })
+      queryClient.invalidateQueries({ queryKey: ['events'] })
+      queryClient.invalidateQueries({ queryKey: ['calendars'] })
+      queryClient.invalidateQueries({ queryKey: ['unreadCount'] })
+    })
+    return () => {
+      unlisten.then((fn) => fn())
+    }
+  }, [])
+
   // Listen for notification:open_thread events to pre-select a thread.
   // Don't switch the active view — the event fires for every new message
   // during background sync, not only when the user clicks a notification.
@@ -199,6 +215,7 @@ function AppShell() {
       >
         <UpdateBanner />
         <NotificationBanner />
+        <AuthExpiredBanner accounts={accounts} />
         <TopBar activeAccounts={activeAccountObjects} />
         {activeView === 'mail' && (
           <MailView

--- a/src/__tests__/AuthExpiredBanner.test.tsx
+++ b/src/__tests__/AuthExpiredBanner.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Account } from '../types/models'
+import AuthExpiredBanner from '../components/AuthExpiredBanner'
+
+const HEALTHY_ACCOUNT: Account = {
+  id: 'a1',
+  email: 'work@test.com',
+  display_name: 'Work',
+  color: '#4f9cf9',
+  history_id: '',
+  auth_expired: false,
+}
+
+const EXPIRED_ACCOUNT: Account = {
+  id: 'a2',
+  email: 'expired@test.com',
+  display_name: 'Expired User',
+  color: '#f97316',
+  history_id: '',
+  auth_expired: true,
+}
+
+const EXPIRED_ACCOUNT_2: Account = {
+  id: 'a3',
+  email: 'also-expired@test.com',
+  display_name: 'Also Expired',
+  color: '#a78bfa',
+  history_id: '',
+  auth_expired: true,
+}
+
+function renderBanner(accounts: Account[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthExpiredBanner accounts={accounts} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AuthExpiredBanner', () => {
+  it('should not render when no accounts have expired auth', () => {
+    renderBanner([HEALTHY_ACCOUNT])
+    expect(screen.queryByTestId('auth-expired-banner')).not.toBeInTheDocument()
+  })
+
+  it('should not render when account list is empty', () => {
+    renderBanner([])
+    expect(screen.queryByTestId('auth-expired-banner')).not.toBeInTheDocument()
+  })
+
+  it('should render when one account has expired auth', () => {
+    renderBanner([HEALTHY_ACCOUNT, EXPIRED_ACCOUNT])
+    expect(screen.getByTestId('auth-expired-banner')).toBeInTheDocument()
+    expect(screen.getByText('Expired User')).toBeInTheDocument()
+    expect(screen.getByText(/needs to be re-authenticated/)).toBeInTheDocument()
+  })
+
+  it('should show re-authenticate button for a single expired account', () => {
+    renderBanner([EXPIRED_ACCOUNT])
+    expect(screen.getByText('Re-authenticate')).toBeInTheDocument()
+  })
+
+  it('should render multiple expired account names', () => {
+    renderBanner([HEALTHY_ACCOUNT, EXPIRED_ACCOUNT, EXPIRED_ACCOUNT_2])
+    expect(screen.getByText('Expired User')).toBeInTheDocument()
+    expect(screen.getByText('Also Expired')).toBeInTheDocument()
+    expect(screen.getByText(/need to be re-authenticated/)).toBeInTheDocument()
+  })
+
+  it('should not show re-authenticate button for multiple expired accounts', () => {
+    renderBanner([EXPIRED_ACCOUNT, EXPIRED_ACCOUNT_2])
+    expect(screen.queryByText('Re-authenticate')).not.toBeInTheDocument()
+  })
+
+  it('should dismiss when the dismiss button is clicked', async () => {
+    const user = userEvent.setup()
+    renderBanner([EXPIRED_ACCOUNT])
+
+    expect(screen.getByTestId('auth-expired-banner')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Dismiss auth expired banner'))
+    expect(screen.queryByTestId('auth-expired-banner')).not.toBeInTheDocument()
+  })
+
+  it('should fall back to email when display_name is empty', () => {
+    const noName: Account = { ...EXPIRED_ACCOUNT, display_name: '' }
+    renderBanner([noName])
+    expect(screen.getByText('expired@test.com')).toBeInTheDocument()
+  })
+})

--- a/src/components/AuthExpiredBanner.module.css
+++ b/src/components/AuthExpiredBanner.module.css
@@ -1,0 +1,62 @@
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--bg-warning);
+  color: var(--text-on-warning);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.banner svg {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+}
+
+.message {
+  flex: 1;
+}
+
+.accountName {
+  font-weight: 600;
+}
+
+.reauthButton {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.reauthButton:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.reauthButton:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.dismissButton {
+  flex-shrink: 0;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.7;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.dismissButton:hover {
+  opacity: 1;
+}

--- a/src/components/AuthExpiredBanner.tsx
+++ b/src/components/AuthExpiredBanner.tsx
@@ -1,0 +1,74 @@
+import { useState, useCallback } from 'react'
+import type { Account } from '../types/models'
+import { useReauthAccount } from '../hooks/useAccounts'
+import styles from './AuthExpiredBanner.module.css'
+
+interface AuthExpiredBannerProps {
+  accounts: Account[]
+}
+
+/**
+ * In-app warning banner shown when one or more accounts have expired
+ * or revoked OAuth tokens. Displays the affected account names and
+ * offers a re-authenticate button. Dismissible per session.
+ */
+export default function AuthExpiredBanner({ accounts }: AuthExpiredBannerProps) {
+  const [dismissed, setDismissed] = useState(false)
+  const reauthAccount = useReauthAccount()
+
+  const expiredAccounts = accounts.filter((a) => a.auth_expired)
+
+  const handleReauth = useCallback(
+    (accountId: string) => {
+      reauthAccount.mutate(accountId)
+    },
+    [reauthAccount],
+  )
+
+  if (dismissed || expiredAccounts.length === 0) {
+    return null
+  }
+
+  const names = expiredAccounts.map((a) => a.display_name || a.email)
+
+  return (
+    <div className={styles.banner} role="alert" data-testid="auth-expired-banner">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+      </svg>
+      <span className={styles.message}>
+        {expiredAccounts.length === 1 ? (
+          <>
+            <span className={styles.accountName}>{names[0]}</span> needs to be re-authenticated.
+          </>
+        ) : (
+          <>
+            {names.map((name, i) => (
+              <span key={expiredAccounts[i].id}>
+                {i > 0 && ', '}
+                <span className={styles.accountName}>{name}</span>
+              </span>
+            ))}{' '}
+            need to be re-authenticated.
+          </>
+        )}
+      </span>
+      {expiredAccounts.length === 1 && (
+        <button
+          className={styles.reauthButton}
+          onClick={() => handleReauth(expiredAccounts[0].id)}
+          disabled={reauthAccount.isPending}
+        >
+          {reauthAccount.isPending ? 'Signing in...' : 'Re-authenticate'}
+        </button>
+      )}
+      <button
+        className={styles.dismissButton}
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss auth expired banner"
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
 import { getVersion } from '@tauri-apps/api/app'
-import { listen } from '@tauri-apps/api/event'
 import type { Account, Calendar } from '../types/models'
 import { MAIL_LABELS } from '../types/models'
 import type { Theme, AppView, WeekStartDay } from '../store/uiStore'
@@ -41,17 +40,6 @@ export default function Sidebar({ accounts, unreadCount, calendars }: SidebarPro
     getVersion()
       .then(setVersion)
       .catch(() => {})
-  }, [])
-
-  // Listen for backend auth-expired events and refresh the account list
-  useEffect(() => {
-    const unlisten = listen('account:auth_expired', () => {
-      // The accounts query will be invalidated automatically via the query cache,
-      // but we trigger a re-render to show the warning indicator
-    })
-    return () => {
-      unlisten.then((fn) => fn())
-    }
   }, [])
 
   const handleDelete = useCallback(


### PR DESCRIPTION
Fixes #42

## Problem

When a Google OAuth token expired or was revoked while Mogly was running, the re-authenticate option only appeared after restarting the app. The backend already detected auth failures and emitted `account:auth_expired`, but the frontend event listener in Sidebar was a no-op — it never invalidated the accounts query.

## Changes

**App.tsx:** Added a `useEffect` listener for `account:auth_expired` that invalidates all relevant TanStack Query caches (`accounts`, `messages`, `events`, `calendars`, `unreadCount`). This causes the Sidebar to re-render and immediately show the warning icon and Re-authenticate button.

**AuthExpiredBanner:** New component displayed in the main content area (alongside UpdateBanner and NotificationBanner) that warns the user when any account has expired auth. For single expired accounts it offers a one-click Re-authenticate button. Dismissible per session.

**Sidebar.tsx:** Removed the no-op `account:auth_expired` listener and the unused `listen` import.

## Tests

8 new test cases for AuthExpiredBanner covering: no expired accounts, empty list, single expired, multiple expired, re-auth button visibility, dismiss behavior, and email fallback.