### PR TITLE
fix: prevent all-day events from spilling onto next day in positive-UTC-offset timezones

### DIFF
--- a/src/__tests__/CalendarView.test.tsx
+++ b/src/__tests__/CalendarView.test.tsx
@@ -364,8 +364,8 @@ describe('CalendarView', () => {
       makeEvent({
         id: 'multi1',
         title: 'Conference',
-        start: new Date('2026-03-04T00:00:00').getTime() / 1000,
-        end: new Date('2026-03-07T00:00:00').getTime() / 1000,
+        start: new Date('2026-03-04T00:00:00Z').getTime() / 1000,
+        end: new Date('2026-03-07T00:00:00Z').getTime() / 1000,
         all_day: true,
       }),
     ]
@@ -384,14 +384,43 @@ describe('CalendarView', () => {
     expect(conferenceEls.length).toBe(3)
   })
 
+  it('does not spill single-day all-day event into the next day (exclusive end date)', () => {
+    // Google Calendar uses exclusive end dates: a single-day event on Wed Mar 4
+    // has start=2026-03-04T00:00:00Z and end=2026-03-05T00:00:00Z.
+    // In positive-UTC-offset timezones, local midnight is earlier than UTC midnight,
+    // which previously caused the event to also appear on Thursday.
+    const events = [
+      makeEvent({
+        id: 'single-ad',
+        title: 'Single Day Off',
+        start: new Date('2026-03-04T00:00:00Z').getTime() / 1000,
+        end: new Date('2026-03-05T00:00:00Z').getTime() / 1000,
+        all_day: true,
+      }),
+    ]
+
+    const { container } = render(
+      <Wrapper>
+        <CalendarView events={events} accounts={MOCK_ACCOUNTS} isLoading={false} />
+      </Wrapper>,
+    )
+
+    const allDayEls = container.querySelectorAll('[class*="allDayEvent"]')
+    const matchingEls = Array.from(allDayEls).filter((el) =>
+      el.textContent?.includes('Single Day Off'),
+    )
+    // Must appear in exactly 1 day column, not 2
+    expect(matchingEls.length).toBe(1)
+  })
+
   it('renders multi-day event that starts before the visible week', () => {
     // Event starts on Sunday Mar 1 (before the Monday start) and ends Wed Mar 4
     const events = [
       makeEvent({
         id: 'pre-week',
         title: 'Sprint',
-        start: new Date('2026-03-01T00:00:00').getTime() / 1000,
-        end: new Date('2026-03-05T00:00:00').getTime() / 1000,
+        start: new Date('2026-03-01T00:00:00Z').getTime() / 1000,
+        end: new Date('2026-03-05T00:00:00Z').getTime() / 1000,
         all_day: true,
       }),
     ]

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -534,21 +534,23 @@ export default function CalendarView({
 
     if (!events) return map
 
-    for (const event of events) {
-      // Treat events spanning 24h+ as all-day (some holiday calendars
-      // return full-day events as timed events spanning midnight-to-midnight)
-      const isAllDay = event.all_day || event.end - event.start >= 86400
+    // Iterate days in outer loop so boundaries are computed once per column.
+    // All-day events use UTC boundaries (Google returns UTC-midnight timestamps);
+    // timed events use local boundaries.
+    for (let i = 0; i < dayCount; i++) {
+      const day = weekDays[i]
+      const dayStartLocal =
+        new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime() / 1000
+      const dayEndLocal = dayStartLocal + 86400
+      const dayStartUtc = Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()) / 1000
+      const dayEndUtc = dayStartUtc + 86400
 
-      // Find all day columns this event overlaps with (supports multi-day events)
-      for (let i = 0; i < dayCount; i++) {
-        const day = weekDays[i]
-        const dayStartTs =
-          new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime() / 1000
-        const dayEndTs = dayStartTs + 86400
+      for (const event of events) {
+        const isAllDay = event.all_day || event.end - event.start >= 86400
+        const ds = isAllDay ? dayStartUtc : dayStartLocal
+        const de = isAllDay ? dayEndUtc : dayEndLocal
 
-        // Event overlaps this day if it starts before the day ends
-        // and ends after the day starts
-        if (event.start < dayEndTs && event.end > dayStartTs) {
+        if (event.start < de && event.end > ds) {
           if (isAllDay) {
             map.get(i)!.allDay.push(event)
           } else {

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -85,15 +85,31 @@ export default function MonthView({
     const map = new Map<string, CalEvent[]>()
     if (!events) return map
     for (const ev of events) {
-      const startD = new Date(ev.start * 1000)
-      // Iterate each day the event spans
-      const cursor = new Date(startD.getFullYear(), startD.getMonth(), startD.getDate())
-      while (cursor.getTime() / 1000 < ev.end) {
-        const key = `${cursor.getFullYear()}-${pad2(cursor.getMonth() + 1)}-${pad2(cursor.getDate())}`
-        const list = map.get(key) ?? []
-        list.push(ev)
-        map.set(key, list)
-        cursor.setDate(cursor.getDate() + 1)
+      const isAllDay = ev.all_day || ev.end - ev.start >= 86400
+      if (isAllDay) {
+        // All-day event timestamps are UTC midnight — compare in UTC
+        const startD = new Date(ev.start * 1000)
+        const cursor = new Date(
+          Date.UTC(startD.getUTCFullYear(), startD.getUTCMonth(), startD.getUTCDate()),
+        )
+        while (cursor.getTime() / 1000 < ev.end) {
+          const key = `${cursor.getUTCFullYear()}-${pad2(cursor.getUTCMonth() + 1)}-${pad2(cursor.getUTCDate())}`
+          const list = map.get(key) ?? []
+          list.push(ev)
+          map.set(key, list)
+          cursor.setUTCDate(cursor.getUTCDate() + 1)
+        }
+      } else {
+        // Timed events — use local time
+        const startD = new Date(ev.start * 1000)
+        const cursor = new Date(startD.getFullYear(), startD.getMonth(), startD.getDate())
+        while (cursor.getTime() / 1000 < ev.end) {
+          const key = `${cursor.getFullYear()}-${pad2(cursor.getMonth() + 1)}-${pad2(cursor.getDate())}`
+          const list = map.get(key) ?? []
+          list.push(ev)
+          map.set(key, list)
+          cursor.setDate(cursor.getDate() + 1)
+        }
       }
     }
     return map


### PR DESCRIPTION
## Problem

Single-day all-day events appear on the following day for users in positive-UTC-offset timezones (e.g. UTC+2, UTC+3).

Google Calendar API uses exclusive end dates for all-day events — a single-day event on March 15 has `end: "2026-03-16"`. The Rust backend converts these to UTC midnight timestamps. The frontend was computing day boundaries using local midnight (`new Date(year, month, date)`), which in positive-offset timezones is earlier than UTC midnight, causing the overlap check to match the next day.

## Fix

- **CalendarView.tsx**: Use UTC-based day boundaries (`Date.UTC()`) for all-day event overlap checks; timed events continue using local-time boundaries.
- **MonthView.tsx**: Use UTC-based cursor advancement for all-day events when iterating the days an event spans.
- **CalendarView.test.tsx**: Added test verifying single-day all-day events with exclusive end dates only appear in one day column.