### PR TITLE
fix: unread count badge does not refresh after mark-read/unread or archive

### DIFF
--- a/src/__tests__/EmailDetail.test.tsx
+++ b/src/__tests__/EmailDetail.test.tsx
@@ -54,7 +54,8 @@ function renderWithQuery(ui: React.ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+  const result = render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+  return { ...result, queryClient }
 }
 
 describe('EmailDetail', () => {
@@ -334,5 +335,71 @@ describe('EmailDetail', () => {
     await user.click(checkbox)
 
     expect(useUIStore.getState().autoMarkRead).toBe(true)
+  })
+
+  it('should invalidate unreadCount query after marking a thread unread', async () => {
+    const user = userEvent.setup()
+    mockedInvoke.mockResolvedValueOnce(MOCK_THREAD).mockResolvedValueOnce(undefined)
+
+    const { queryClient } = renderWithQuery(
+      <EmailDetail
+        accounts={MOCK_ACCOUNTS}
+        selectedMessage={{ ...MOCK_SELECTED_MESSAGE, unread: false }}
+      />,
+    )
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await waitFor(() => {
+      expect(screen.getByText('○ Mark unread')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('○ Mark unread'))
+
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['unreadCount'] })
+    })
+  })
+
+  it('should invalidate unreadCount query after marking a thread read', async () => {
+    const user = userEvent.setup()
+    mockedInvoke.mockResolvedValueOnce(MOCK_THREAD).mockResolvedValueOnce(undefined)
+
+    const { queryClient } = renderWithQuery(
+      <EmailDetail
+        accounts={MOCK_ACCOUNTS}
+        selectedMessage={{ ...MOCK_SELECTED_MESSAGE, unread: true }}
+      />,
+    )
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await waitFor(() => {
+      expect(screen.getByText('✓ Mark read')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('✓ Mark read'))
+
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['unreadCount'] })
+    })
+  })
+
+  it('should invalidate unreadCount query after archiving a thread', async () => {
+    const user = userEvent.setup()
+    mockedInvoke.mockResolvedValueOnce(MOCK_THREAD).mockResolvedValueOnce(undefined)
+
+    const { queryClient } = renderWithQuery(
+      <EmailDetail accounts={MOCK_ACCOUNTS} selectedMessage={MOCK_SELECTED_MESSAGE} />,
+    )
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await waitFor(() => {
+      expect(screen.getByText('Archive')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Archive'))
+
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['unreadCount'] })
+    })
   })
 })

--- a/src/components/EmailDetail.tsx
+++ b/src/components/EmailDetail.tsx
@@ -103,6 +103,7 @@ export default function EmailDetail({ accounts, selectedMessage }: EmailDetailPr
       invoke('mark_read', { accountId, threadId: selectedThreadId }).then(() => {
         queryClient.invalidateQueries({ queryKey: ['messages'] })
         queryClient.invalidateQueries({ queryKey: ['search'] })
+        queryClient.invalidateQueries({ queryKey: ['unreadCount'] })
       })
     }, 2000)
 
@@ -121,6 +122,7 @@ export default function EmailDetail({ accounts, selectedMessage }: EmailDetailPr
       await invoke(command, { accountId, threadId: selectedThreadId })
       queryClient.invalidateQueries({ queryKey: ['messages'] })
       queryClient.invalidateQueries({ queryKey: ['search'] })
+      queryClient.invalidateQueries({ queryKey: ['unreadCount'] })
     } catch (e) {
       console.error(`${command} failed:`, e)
     }
@@ -131,6 +133,7 @@ export default function EmailDetail({ accounts, selectedMessage }: EmailDetailPr
     try {
       await invoke('archive_thread', { accountId, threadId: selectedThreadId })
       queryClient.invalidateQueries({ queryKey: ['messages'] })
+      queryClient.invalidateQueries({ queryKey: ['unreadCount'] })
       useUIStore.getState().setSelectedThreadId(null)
     } catch (e) {
       console.error('Archive failed:', e)

--- a/src/components/MailView.tsx
+++ b/src/components/MailView.tsx
@@ -55,6 +55,7 @@ export default function MailView({ accounts, messages, isLoading }: MailViewProp
       })
       queryClient.invalidateQueries({ queryKey: ['messages'] })
       queryClient.invalidateQueries({ queryKey: ['search'] })
+      queryClient.invalidateQueries({ queryKey: ['unreadCount'] })
       clearSelection()
     } catch (e) {
       console.error('Batch modify failed:', e)


### PR DESCRIPTION
Closes #55

## Problem

The unread badge (sidebar + tray tooltip) was only refreshed when a `mail:new` background sync event fired. Manually marking a thread read/unread, letting auto-mark-read fire, archiving a thread, or using the bulk mark-read/unread action all left the badge stale until the next 2-minute background poll.

## Root cause

`EmailDetail.tsx` and `MailView.tsx` invalidated `messages` and `search` queries after read-state changes, but never invalidated the `unreadCount` query. The `useUnreadCount` hook (which calls the Gmail Labels API for accurate server-side counts) was therefore not re-triggered.

## Fix

Add `queryClient.invalidateQueries({ queryKey: ['unreadCount'] })` alongside the existing query invalidations in:

- `EmailDetail.tsx` — auto-mark-read timer, `handleMarkReadUnread`, `handleArchive`
- `MailView.tsx` — `handleBulkAction` (bulk mark-read/unread)

## Tests

Three new test cases in `EmailDetail.test.tsx` verify that `unreadCount` is invalidated after marking unread, marking read, and archiving.